### PR TITLE
Add PR body template (Phase 1 review protocol)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Why
+<!-- 1-2 sentences: the user ask or handoff issue # driving this change -->
+
+## Approach
+<!-- What this PR does and why THIS approach. Files/pages affected. -->
+
+## Alternatives Considered
+<!-- At least one — "none" is valid but must be explicit. -->
+
+## Self-Identified Risks
+<!-- e.g., "command may have been renamed", "i18n gap in RU", "example not yet tested on Windows". Cannot be empty. -->
+
+## Verification Log
+<!-- Concrete evidence:
+- feature/command grep vs docplatform source
+- code-example run (output pasted)
+- internal-link check (every link resolves in every locale)
+- i18n coverage (new keys per language) -->
+
+## Context Snapshot
+<!-- Paste the RAW contents of your sessions/active-context.md at PR-open time. -->
+
+## Linked
+- Handoff issue: <!-- #N or "none" -->
+- Related PRs: <!-- #M or "none" -->
+- Related issues: <!-- #J or "none" -->


### PR DESCRIPTION
## Why
Part of Phase 1 review-protocol rollout. A matching template was written
locally and needs to ship to the repo so GitHub pre-fills the body on
"New PR" clicks.

## Approach
Add a single file .github/pull_request_template.md. No code change,
no config change, no dependency change. GitHub auto-uses it for any
new PR against this repo.

## Alternatives Considered
- Org-level default template: rejected. Different repos have slightly
  different Verification Log expectations (go tests vs hugo build vs
  doc source-greps). A per-repo template is clearer.
- Skipping the template and relying on the rule in .claude/rules/: rejected.
  GitHub's native pre-fill is the only way the template reliably shows
  up when PRs are opened via the web UI.

## Self-Identified Risks
None — adds a pure markdown helper, no behavior change, no build impact.
Worst case: the template is wrong wording and needs a follow-up edit.

## Verification Log
- File exists and matches canonical template: diff .github/pull_request_template.md
  C:/Valoryx/.workspace/PR-BODY-TEMPLATE.md (structural match, wording
  adapted to this repo's Verification Log domain).
- No other files touched: git diff --stat shows 1 file added, 0 modified.
- CI impact: none (template is not read by any workflow).

## Context Snapshot
```
---
agent: build-agent
session_started: null
last_updated: null
north_star: null
current_task: null
next_action: null
status: session-ended
---

## Decisions & Why
_(none — template. First session will populate.)_

## Files Touched This Session
_(none)_

## Open Artifacts
- PRs opened this session: none
- Issues filed: none
- Handoffs: none
- Branches active: none

## Blocking Questions
- none

## Do-Not-Lose
_(nothing yet — this is a fresh template)_

## Resume Hints
- On first boot, treat status=session-ended as "no active work; start from pending handoffs or user instruction."
- Read `.claude/rules/process/checkpoint-protocol.md` for full schema and rules.
```

## Linked
- Handoff issue: Valoryx-org/issues#8
- Related PRs: Valoryx-org/docplatform#246, Valoryx-org/valoryx.org#19
- Related issues: none
