### PR TITLE
docs: full accuracy pass against docplatform main 64c2e84 (v0.11.1)

### DIFF
--- a/configuration/authentication.md
+++ b/configuration/authentication.md
@@ -84,8 +84,8 @@ Each time a refresh token is used, a new refresh token is issued and the old one
 | Variable | Default | Description |
 |---|---|---|
 | `JWT_KEY_PATH` | `{DATA_DIR}/jwt-private.pem` | Path to the RS256 private key |
-| `JWT_ACCESS_TTL` | `900` | Access token lifetime in seconds (default: 15 minutes) |
-| `JWT_REFRESH_TTL` | `604800` | Refresh token lifetime in seconds (default: 7 days) |
+
+Token lifetimes are fixed at 15 minutes (access) and 7 days (refresh) and are not configurable.
 
 ### Key management
 
@@ -124,8 +124,8 @@ Restart the server. A **Sign in with Google** button appears on the login page.
 
 When a user signs in via Google for the first time:
 
-- A DocPlatform account is created with their Google email
-- They're assigned the default role (`permissions.default_role`) in any workspace they're invited to
+- A DocPlatform account is created with their Google email, along with their own organization (same as local registration)
+- Workspace access comes from invitations — the inviter picks the role
 - No password is set (they can add one later from their profile)
 
 ## GitHub OIDC sign-in (optional)
@@ -150,7 +150,7 @@ Restart the server. A **Sign in with GitHub** button appears on the login page.
 
 ### User provisioning
 
-Same as Google — a DocPlatform account is created using the GitHub primary email. If the GitHub account has no public email, the user is prompted to enter one.
+Same as Google — a DocPlatform account is created using the GitHub primary email, which DocPlatform fetches via the `user:email` OAuth scope (it works even when the email is not public on the GitHub profile).
 
 ## WebAuthn / Passkeys (optional)
 
@@ -212,7 +212,21 @@ For programmatic access (CI/CD pipelines, MCP integrations, scripts), use API ke
 | Delete key | `DELETE /api/v1/api-keys/:id` |
 | Rotate key | `POST /api/v1/api-keys/:id/rotate` |
 
-Keys are scoped to the organization. Set `API_KEY_PEPPER` (or `DOCPLATFORM_API_KEY_PEPPER`) for HMAC hashing security.
+### Scopes
+
+Each key carries a set of scopes checked on every request:
+
+| Scope | Grants |
+|---|---|
+| `read` | GET/HEAD/OPTIONS requests |
+| `write` | POST/PUT/PATCH (implies `read`) |
+| `delete` | DELETE (implies `read`) |
+| `admin` | All methods |
+| `admin:read` | Read-only platform-owner access |
+
+New keys default to `["read", "write", "delete"]`. An optional `expires_at` (Unix seconds) can be set at creation. API-key requests must **also** pass the caller's workspace role check — a scope never grants more than the underlying role allows.
+
+Set `API_KEY_PEPPER` (or `DOCPLATFORM_API_KEY_PEPPER`) for HMAC hashing security.
 
 ## Session management
 
@@ -225,20 +239,23 @@ DocPlatform tracks active sessions per user:
 | **Created** | When the session was established |
 | **Last active** | Most recent API request |
 
-Users can view and revoke sessions from their profile page. Admins can view all sessions from the admin panel.
+Users can view their active sessions from their profile page (`GET /api/auth/sessions`).
 
 ### Revoking sessions
 
-- **User-initiated** — Profile → Sessions → Revoke
-- **Admin-initiated** — Admin → Users → select user → Revoke All Sessions
-- **Key rotation** — Deleting the JWT key invalidates all sessions globally
+- **Logout** — ends the current session immediately (the session record is deleted, so even unexpired access tokens stop working)
+- **Password reset** — all of the user's sessions are revoked automatically
+- **Refresh-token replay** — if a rotated refresh token is ever reused, all of that user's sessions are revoked as a defensive measure
+- **Key rotation** — deleting the JWT key invalidates all sessions globally
 
 ## Password policy
 
 | Constraint | Value |
 |---|---|
 | Minimum length | 8 characters |
+| Maximum length | 1024 characters |
 | Hashing | argon2id (64 MB memory, 3 iterations, parallelism 2) |
+| Account lockout | 5 failed login attempts → 15-minute lockout |
 
 Passwords are validated on registration and password reset. DocPlatform does not enforce character-class requirements (uppercase, special characters) — length is the primary security measure per current NIST guidelines.
 
@@ -249,9 +266,9 @@ WebSocket connections use an HttpOnly cookie mechanism to avoid exposing tokens 
 **Flow:**
 
 1. Client calls `POST /api/auth/ws-token` with a valid JWT
-2. Server sets a `dp_ws_token` HttpOnly cookie (valid for **30 seconds**, single-use)
+2. Server sets a `dp_ws_token` HttpOnly, SameSite=Strict cookie (valid for 1 hour)
 3. Client connects to `ws://host/ws` — the browser sends the cookie automatically
-4. Server validates the cookie, establishes the WebSocket, and clears the cookie
+4. Server validates the cookie and establishes the WebSocket
 
 This is transparent to users — the web editor handles token acquisition automatically.
 

--- a/configuration/environment.md
+++ b/configuration/environment.md
@@ -5,15 +5,15 @@ description: Complete reference for all DocPlatform environment variables — se
 
 # Environment Variables
 
-DocPlatform reads configuration from environment variables. Set them in your shell, a `.env` file in the working directory, or your container orchestrator.
+DocPlatform reads configuration from environment variables only — there is no config file. Set them in your shell, your systemd unit, or your container orchestrator.
 
 ## Server
 
 | Variable | Default | Description |
 |---|---|---|
 | `PORT` | `3000` | HTTP listen port |
-| `HOST` | `0.0.0.0` | **Not yet implemented.** Reserved for future use. |
 | `DATA_DIR` | `.docplatform` | Root directory for all DocPlatform data (database, backups, workspaces, keys) |
+| `DOCPLATFORM_ENV` | — | Set to `production` to enable strict configuration validation (e.g., requires `API_KEY_PEPPER`, blocks `DEV_FRONTEND_URL`) |
 | `BASE_URL` | `http://localhost:{PORT}` | Public URL used for OIDC callbacks, invitation links, and email templates. Set to your production URL (e.g., `https://docs.example.com`). |
 | `BASE_DOMAIN` | — | Custom domain for published docs (e.g., `docs.yourcompany.com`). When set, published docs use this domain for canonical URLs and sitemap entries. |
 | `PUBLISH_REQUIRE_AUTH` | `false` | When `true`, all published documentation sites require the visitor to be logged in as a workspace member. Unauthenticated visitors are redirected to the login page and returned to the original page after sign-in. |
@@ -24,11 +24,11 @@ DocPlatform reads configuration from environment variables. Set them in your she
 | Variable | Default | Description |
 |---|---|---|
 | `JWT_KEY_PATH` | `{DATA_DIR}/jwt-private.pem` | Path to the RS256 private key for JWT signing. Auto-generated on first run if missing (2048-bit RSA). |
-| `JWT_ACCESS_TTL` | `900` | Access token lifetime in seconds (default: 15 minutes) |
-| `JWT_REFRESH_TTL` | `604800` | Refresh token lifetime in seconds (default: 7 days) |
 | `ARGON2_MEMORY` | `65536` | Argon2id memory parameter in KiB (default: 64 MB) |
 | `ARGON2_TIME` | `3` | Argon2id iteration count |
 | `ARGON2_THREADS` | `2` | Argon2id parallelism |
+
+Token lifetimes are fixed: access tokens live 15 minutes, refresh tokens 7 days (with single-use rotation). They are not configurable via environment variables.
 
 ## OIDC providers (optional)
 
@@ -63,9 +63,10 @@ See [Authentication](authentication.md) for setup instructions.
 | `GIT_SSH_KNOWN_HOSTS` | — | Path to known_hosts file for strict host verification. If not set, uses built-in pinned keys for GitHub, GitLab, and Bitbucket. |
 | `GIT_SYNC_INTERVAL` | `300` | Default polling interval in seconds for remote sync (minimum: 10). Overridden by per-workspace `sync_interval`. |
 | `GIT_AUTO_COMMIT` | `true` | Default auto-commit behavior. Overridden by per-workspace `git_auto_commit`. |
-| `GIT_WEBHOOK_SECRET` | — | Shared secret for verifying webhook payloads (HMAC-SHA256) from GitHub, GitLab, or Bitbucket. |
-| `GIT_COMMIT_NAME` | `DocPlatform` | Hardcoded, not configurable. Shown here for reference only. |
-| `GIT_COMMIT_EMAIL` | `docplatform@local` | Hardcoded, not configurable. Shown here for reference only. |
+| `GIT_ENCRYPTION_KEY` | — | Master key (minimum 16 characters) used to encrypt git provider tokens at rest (AES-256-GCM with Argon2id key derivation). Required to connect git providers with a personal access token. |
+| `GIT_ALLOWLIST_PRIVATE` | `false` | Community Edition: set to `true` to allow private git remote URLs. |
+
+Incoming git webhooks are verified with a **per-workspace secret** that DocPlatform generates automatically (32-byte random hex) — find it in **Workspace Settings → Git**. There is no global webhook secret variable. Commits from editor saves carry the acting user's identity as the git author; automatic conflict-merge commits are authored as `sync@valoryx.dev`.
 
 ## Email (optional)
 
@@ -87,7 +88,8 @@ Configure SMTP or Resend for workspace invitations and password reset emails. Wi
 |---|---|---|
 | `BACKUP_ENABLED` | `true` | Enable daily automated SQLite backups |
 | `BACKUP_RETENTION_DAYS` | `7` | Number of days to retain backup files. Older backups are deleted automatically. |
-| `BACKUP_DIR` | `{DATA_DIR}/backups` | Directory for backup files |
+
+Backups are always written to `{DATA_DIR}/backups/` — the location is not separately configurable.
 
 ## Telemetry
 
@@ -105,9 +107,11 @@ Configure SMTP or Resend for workspace invitations and password reset emails. Wi
 
 Telemetry **never** sends: page content, user emails, IP addresses, file names, or any personally identifiable information. Frequency: weekly.
 
-## Stripe billing (optional)
+## Stripe billing (Cloud edition only)
 
-Enable subscription billing with Stripe. When `STRIPE_SECRET_KEY` is not set, billing is disabled and all organizations are treated as unlimited.
+> These variables exist only in the **Cloud edition** that powers [app.valoryx.dev](https://app.valoryx.dev). The Community Edition binary contains no billing code at all — these variables have no effect on a self-hosted install, and every Community organization is unlimited by design.
+
+When `STRIPE_SECRET_KEY` is not set, billing is disabled and all organizations are treated as unlimited.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -143,7 +147,7 @@ Configure Caddy integration for automatic TLS provisioning on custom domains.
 
 | Variable | Default | Description |
 |---|---|---|
-| `API_KEY_PEPPER` | — | HMAC pepper for API key hashing. Warns if empty (reduced entropy). Can also be set as `DOCPLATFORM_API_KEY_PEPPER`. |
+| `API_KEY_PEPPER` | — | HMAC pepper for API key hashing. **Required when `DOCPLATFORM_ENV=production`.** Can also be set as `DOCPLATFORM_API_KEY_PEPPER`. |
 | `HIDE_STORAGE_PATHS` | `false` | Suppress disk paths in API responses (recommended for cloud/SaaS deployments). |
 | `SHOW_DISK_PATHS_TO_WS_ADMIN` | `false` | Opt-in: show disk paths to workspace admins in storage info responses. |
 
@@ -151,20 +155,34 @@ Configure Caddy integration for automatic TLS provisioning on custom domains.
 
 | Variable | Default | Description |
 |---|---|---|
-| `FF_METRICS` | `false` | Enable Prometheus metrics at `/metrics` (super admin authentication required). |
+| `FF_METRICS` | `false` | Enable Prometheus metrics at `/metrics` on the main port (platform-owner authentication required). |
+| `METRICS_PORT` | — | When set, additionally exposes an unauthenticated `/metrics` listener bound to `127.0.0.1:{port}` for local Prometheus scraping. |
+
+## Updates
+
+| Variable | Default | Description |
+|---|---|---|
+| `DISABLE_UPDATE_CHECK` | `false` | Skip the startup check for new DocPlatform versions. |
 
 ## Development
 
 | Variable | Default | Description |
 |---|---|---|
-| `DEV_FRONTEND_URL` | — | Proxy non-API requests to this URL for frontend hot module reloading during development. |
+| `DEV_FRONTEND_URL` | — | Proxy non-API requests to this URL for frontend hot module reloading during development. Blocked when `DOCPLATFORM_ENV=production`. |
 
-## Using a `.env` file
+## Setting variables for a service
 
-Create a `.env` file in the directory where you run `docplatform serve`:
+DocPlatform does **not** read `.env` files — variables must be present in the process environment. For a systemd deployment, use an `EnvironmentFile`:
+
+```ini
+# /etc/systemd/system/docplatform.service (excerpt)
+[Service]
+EnvironmentFile=/etc/docplatform/env
+ExecStart=/usr/local/bin/docplatform serve
+```
 
 ```bash
-# .env
+# /etc/docplatform/env  (chmod 600)
 PORT=8080
 DATA_DIR=/var/lib/docplatform
 GIT_SSH_KEY_PATH=/etc/docplatform/deploy_key
@@ -175,8 +193,6 @@ SMTP_USERNAME=docs@example.com
 SMTP_PASSWORD=app-specific-password
 BACKUP_RETENTION_DAYS=30
 ```
-
-DocPlatform loads the `.env` file automatically. Environment variables set in the shell take precedence over `.env` values.
 
 ## Docker environment
 

--- a/configuration/index.md
+++ b/configuration/index.md
@@ -13,11 +13,11 @@ Configuration is applied in three layers, from broadest to most specific:
 
 | Layer | Scope | Method |
 |---|---|---|
-| **Environment variables** | Platform-wide | `.env` file or shell environment |
-| **Workspace config** | Per workspace | `.docplatform/config.yaml` |
+| **Environment variables** | Platform-wide | Shell environment / service unit / container env |
+| **Workspace settings** | Per workspace | Web UI (Settings) — stored in the database; display settings also live in `.docplatform/workspace.yaml` |
 | **Page frontmatter** | Per page | YAML block in each `.md` file |
 
-Higher-specificity layers override lower ones. For example, a page's `access.read` rules restrict visibility beyond the workspace-level defaults.
+Higher-specificity layers override lower ones. For example, a page's frontmatter `publish:` flag controls whether that page appears on the published site, and the `.docplatform/publish.yaml` overlay can override it per path.
 
 ## Guides
 
@@ -26,7 +26,7 @@ Higher-specificity layers override lower ones. For example, a page's `access.rea
 | [Environment Variables](environment.md) | All platform-level settings: port, data directory, git, SMTP, telemetry |
 | [Workspace Settings](workspace-config.md) | Per-workspace config: git remote, theme, navigation, publishing defaults |
 | [Authentication](authentication.md) | Local auth, OIDC providers (Google, GitHub), JWT settings, password policies |
-| [Roles & Permissions](permissions.md) | 5-level RBAC hierarchy, page-level access control, and permission caching |
+| [Roles & Permissions](permissions.md) | 5-level RBAC hierarchy and how permissions are evaluated |
 
 ## Quick reference
 
@@ -35,10 +35,9 @@ The most common configuration tasks:
 | Task | Where |
 |---|---|
 | Change the server port | `PORT` environment variable |
-| Connect a git repository | Workspace config `git_remote` |
+| Connect a git repository | **Workspace Settings → Git** in the web UI |
 | Enable Google/GitHub sign-in | `OIDC_*` environment variables |
-| Set up email (invitations, password reset) | `SMTP_*` environment variables |
-| Change the default role for new users | Workspace config `permissions.default_role` |
-| Restrict published docs to team members only | `PUBLISH_REQUIRE_AUTH=true` environment variable |
-| Restrict a page to specific roles (web editor) | Page frontmatter `access.read: ["role-name"]` |
-| Disable telemetry | `DOCPLATFORM_TELEMETRY=off` |
+| Set up email (invitations, password reset) | `SMTP_*` or `RESEND_*` environment variables |
+| Choose a role when inviting a member | **Workspace Settings → Members → Invite** |
+| Restrict published docs to team members only | `PUBLISH_REQUIRE_AUTH=true` environment variable, or per-site `visibility: authenticated` (the default) |
+| Telemetry | Off by default; opt in with `DOCPLATFORM_TELEMETRY=on` |

--- a/configuration/permissions.md
+++ b/configuration/permissions.md
@@ -5,7 +5,7 @@ description: Configure DocPlatform's 5-role hierarchy, workspace-level access co
 
 # Roles & Permissions
 
-DocPlatform uses role-based access control (RBAC) powered by custom RBAC, an in-process authorization engine. Permissions are evaluated in under 0.1ms per check with no external service.
+DocPlatform uses role-based access control (RBAC) evaluated in-process — there is no external authorization service to deploy or configure.
 
 ## Role hierarchy
 
@@ -23,7 +23,7 @@ Commenter           ← View pages, leave comments
 Viewer              ← View pages only
 ```
 
-> **Platform Owner** is an internal-only role used by self-hosted operators for platform-level maintenance (database migrations, license management, system config). It does not appear in the UI or API and is not part of the public role hierarchy.
+> **Platform Owner** is an internal flag used by the Valoryx-operated Cloud service. It has no functionality in Community Edition and is not part of the public role hierarchy.
 
 ### Permission matrix
 
@@ -36,12 +36,12 @@ Viewer              ← View pages only
 | Create pages | | | Configurable | Yes | Yes |
 | Delete pages | | | Configurable | Yes | Yes |
 | Upload assets | | | Yes | Yes | Yes |
-| Assign org members to workspace | | | | Yes | Yes |
+| Invite members to the workspace | | | | Yes | Yes |
 | Remove workspace members | | | | Yes | Yes |
 | Change member roles (within workspace) | | | | Yes | Yes |
 | Manage workspace settings | | | | Yes | Yes |
 | Manage theme & navigation | | | | Yes | Yes |
-| Invite external users to org | | | | | Yes |
+| Assign existing org members to any workspace | | | | | Yes |
 | Create/delete workspaces | | | | | Yes |
 | Configure git remote | | | | | Yes |
 | Manage billing & subscription | | | | | Yes |
@@ -69,150 +69,58 @@ curl -X PATCH http://localhost:3000/api/v1/workspaces/:id \
   }'
 ```
 
-**Config file:**
-
-```yaml
-# .docplatform/config.yaml (per workspace)
-permissions:
-  editor_can_create_pages: true
-  editor_can_delete_pages: false
-```
-
 When a permission is disabled, editors see the action as greyed out in the UI and receive `403 Forbidden` from the API.
 
 ## Assigning roles
 
-### First user (Super Admin)
+### Super Admin (org owner)
 
-The first user to register on a new DocPlatform instance automatically receives the **Super Admin** role. This only happens once — subsequent registrations receive no workspace role until invited.
+Registering an account creates a new organization, and the registering user becomes its **Super Admin**. The Super Admin has full control over every workspace in the org, billing, git connections, and org settings.
 
-The Super Admin is the org owner and account creator. They have full control over every workspace, billing, git connections, and external user invitations.
+### Inviting members to a workspace
 
-### Inviting external users
+Workspace **Admins** (and the Super Admin) invite people by email and choose the role at invite time:
 
-Only the **Super Admin** can invite external users to the organization:
-
-**Web UI:** Org Settings → Members → Invite External User
+**Web UI:** Workspace Settings → Members → Invite
 
 **API:**
 
 ```bash
-curl -X POST http://localhost:3000/api/v1/org/invitations \
+curl -X POST http://localhost:3000/api/v1/workspaces/:id/invitations \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/json" \
   -d '{
     "email": "newuser@example.com",
-    "default_role": "editor"
-  }'
-```
-
-The invited user joins the org and can then be assigned to workspaces by any Admin or Super Admin.
-
-### Assigning members to workspaces
-
-**Admins** assign existing org members to their workspace. Admins cannot invite external users — only the Super Admin can do that.
-
-**Web UI:** Workspace Settings → Members → Add Member → select from org members → select role
-
-**API:**
-
-```bash
-curl -X POST http://localhost:3000/api/v1/workspaces/:id/members \
-  -H "Authorization: Bearer {token}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "01HY5K3M7Q8P",
     "role": "editor"
   }'
 ```
 
-### Default role
+If email is configured the invitation is sent automatically; otherwise a shareable invitation link is displayed. Share links (`POST /api/v1/workspaces/:id/share-links`) are an alternative for inviting several people with the same role.
 
-Set the default role for new members added to a workspace without a specific role:
+### Assigning existing org members to workspaces
 
-```yaml
-# .docplatform/config.yaml
-permissions:
-  default_role: viewer
+The org **Super Admin** can assign an existing org member to a workspace:
+
+```bash
+curl -X POST http://localhost:3000/api/v1/org/members/:uid/workspaces \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{ "workspace_id": "01HY5K3M7Q8P", "role": "editor" }'
 ```
 
-Available values: `viewer`, `commenter`, `editor`, `admin`
+Workspace Admins can change the role of existing members of their workspace (**Workspace Settings → Members**, or `PUT /api/v1/workspaces/:id/admin/members/:user_id/role`).
 
-## Page-level access control
+## Page-level access control (not yet enforced)
 
-Override workspace-level permissions on individual pages using frontmatter. Frontmatter access rules **restrict** within a user's role — they never grant permissions beyond the role.
-
-### Access control syntax
-
-Use role-based and user-based access rules to control who can access a page:
-
-```yaml
----
-title: Internal Security Policy
-access:
-  roles: ["security-team", "engineering-leads"]
-  users: ["@01HY5K3M7Q8P"]
----
-```
-
-| Field | Value type | Description |
-|---|---|---|
-| `access.roles` | list of role names | Roles that can access this page |
-| `access.users` | list of `@user_id` | Individual users that can access this page |
-
-**Rules:**
-- Prefix user IDs with `@` to target individual users
-- Super Admin and Admin always have access regardless of frontmatter rules
-- Frontmatter can only **restrict** — a page cannot grant access beyond the user's workspace role
-
-### Examples
-
-**Public page** (default — all workspace members can view):
-
-```yaml
----
-title: Getting Started
----
-```
-
-**Restricted to specific teams:**
-
-```yaml
----
-title: Infrastructure Runbook
-access:
-  roles: ["security-team", "sre-team"]
----
-```
-
-**Restricted with individual user access:**
-
-```yaml
----
-title: Budget Proposal
-access:
-  roles: ["finance-team"]
-  users: ["@01HY5K3M7Q8P"]
----
-```
-
-### What restricted access means
-
-When a page has `access` rules:
-
-- Users without the required role **cannot view** the page
-- The page **does not appear** in search results for unauthorized users
-- Direct URL access returns **403 Forbidden**
+Page frontmatter may contain an `access` block. DocPlatform **parses and preserves** it (it round-trips through git and the editor unchanged), but it is **not enforced** — all access control today is role-based at the workspace level. Do not rely on frontmatter `access` rules to protect content.
 
 ### Published docs access
 
-For the **published docs site** (`/p/{slug}/...`), access control works differently:
+For the **published docs site** (`/p/{slug}/...`), access is controlled per site:
 
-- All published pages are **public by default** — no login required
-- To require login for the entire published site, set [`PUBLISH_REQUIRE_AUTH=true`](environment.md) — this applies to all pages in all workspaces
-- Per-page access control in published docs (e.g., making one page workspace-only while others are public) is planned for a future release
-
-> In v0.5, the `access` frontmatter field is stored and available for future use, but is not enforced on published routes. Use `PUBLISH_REQUIRE_AUTH` for site-wide access restriction.
+- Each published site has a `visibility` setting: `authenticated` (the default — visitors must sign in as workspace members) or `public` (world-readable, no login)
+- The server-wide override [`PUBLISH_REQUIRE_AUTH=true`](environment.md) forces login for **all** published sites regardless of per-site visibility
+- Per-page access control on published sites is not available
 
 ## Internal role levels
 
@@ -248,43 +156,24 @@ Permission Middleware
     └── Denied → 403 Forbidden
 ```
 
-### 5-step evaluation flow
+### 4-step evaluation flow
 
-1. **Is user Platform Owner?** → ALLOW (global bypass)
+1. **Is user Platform Owner?** → ALLOW (global bypass; Cloud edition only)
 2. **Is user Org Super Admin for this workspace's org?** → ALLOW (org-level bypass)
 3. **Look up user's workspace role** → if not a workspace member, DENY
 4. **Does user's role level meet the action's minimum level?** → compare `role_level >= action_min_level`, plus editor permission flags
-5. **Does page frontmatter have access rules?** → check `access.roles`/`access.users`, RESTRICT within role
 
-Frontmatter RESTRICTS within role, never GRANTS beyond it. A malformed frontmatter defaults to **strict mode** — page restricted to Admin only.
+For requests authenticated with an **API key**, the key's scopes are checked first (e.g., a `read`-only key can never write), and then the same role evaluation applies — a scope never grants more than the underlying role allows.
 
-### Performance
-
-| Metric | Value |
-|---|---|
-| **Engine** | custom RBAC (in-process, in-memory) |
-| **Evaluation time** | < 0.1ms per check |
-| **Batch check** | < 1ms per 100 pages |
-| **Cache** | Versioned (auto-invalidated on role or permission change) |
-| **Policy storage** | SQLite (loaded into memory on startup) |
-
-## Permission caching
-
-Custom RBAC policies are loaded from SQLite into memory on server startup. Changes to roles or frontmatter access declarations trigger a cache invalidation:
-
-1. Admin changes a user's role → permission cache version incremented
-2. Editor updates page frontmatter with new `access` rules → cache invalidated for that page
-3. Next permission check loads fresh policy from SQLite
-
-The cache is versioned, not time-based — there's no stale-permission window.
+Permission checks run in-process against the local SQLite database — there is no external authorization service, and role changes take effect on the next request.
 
 ## Plans and seat limits
 
 ### Seat counting
 
-**Super Admin**, **Admin**, and **Editor** roles all count toward the plan's `max_editors` seat limit. Commenter and Viewer roles are **unlimited on all plans** and never count toward any seat limit.
+Workspace members holding the **Editor** or **Admin** role count toward the plan's `max_editors` seat limit (each user is counted once across the org, even if they belong to several workspaces). **Commenter and Viewer roles are unlimited on all plans** and never count toward any seat limit.
 
-When the seat limit is reached, new org members can still be invited — but they can only be assigned Commenter or Viewer roles until a seat is freed.
+When the seat limit is reached, new members can still be invited — but only with the Commenter or Viewer role until a seat is freed.
 
 ### Community Edition
 
@@ -310,24 +199,13 @@ Community Edition is free and self-hosted with no license key required:
 
 ## Common patterns
 
-### Read-only public docs with restricted internal pages
+### Public site, private drafts
 
-```yaml
-# Most pages: no access rules (open to all workspace members)
+Pages are excluded from the published site unless marked for publishing — so editors can draft freely while only reviewed pages go public:
 
-# Internal pages: restricted
----
-title: Incident Response Playbook
-access:
-  roles: ["sre-team", "admin"]
----
-```
-
-### Editor creates, Admin publishes
-
-1. Set `publishing.default_published: false` in workspace config
-2. Editors create and edit pages (unpublished by default)
-3. Admins review and toggle `published: true`
+1. Editors create and edit pages (not published by default)
+2. A reviewer sets `publish: true` in the page frontmatter (or via the editor's publish control)
+3. The `.docplatform/publish.yaml` overlay can override publish decisions per path when you want git-reviewable publish control
 
 ### Team-specific workspaces
 
@@ -341,13 +219,13 @@ Super Admin has access to all workspaces for cross-team visibility. Admins manag
 
 ### Restricting Editor capabilities
 
-For workspaces where editors should only modify existing content:
+For workspaces where editors should only modify existing content, disable the editor flags in workspace settings (or via the API):
 
-```yaml
-# .docplatform/config.yaml
-permissions:
-  editor_can_create_pages: false
-  editor_can_delete_pages: false
+```bash
+curl -X PATCH http://localhost:3000/api/v1/workspaces/:id \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{ "editor_can_create_pages": false, "editor_can_delete_pages": false }'
 ```
 
 Editors can still edit existing pages but cannot create new ones or delete any.
@@ -357,27 +235,20 @@ Editors can still edit existing pages but cannot create new ones or delete any.
 ### "403 Forbidden" on a page I should have access to
 
 1. Check your role: Profile → Workspace Membership
-2. Check the page's frontmatter: does `access.roles` include your role?
-3. Ask a workspace Admin to verify your role assignment
-4. If you are an Editor, check whether the action requires `editor_can_create_pages` or `editor_can_delete_pages` to be enabled
+2. Ask a workspace Admin to verify your role assignment
+3. If you are an Editor, check whether the action requires `editor_can_create_pages` or `editor_can_delete_pages` to be enabled
+4. If you authenticated with an API key, check the key's scopes — a `read` key cannot write regardless of your role
 
 ### Permission changes not taking effect
 
-Permission changes should be instant (cache invalidation is synchronous). If they're not:
+Permission changes are evaluated per request and should be effective immediately. If they're not:
 
 1. Sign out and sign back in (refresh your JWT tokens)
-2. Check the server logs for cache invalidation errors
-3. Run `docplatform doctor` to verify permission system health
+2. Run `docplatform doctor` to check instance health
 
-### First user is not Super Admin
+### I can't see a workspace I expect to see
 
-This happens if the first user registers while the database already contains user records (e.g., from a previous installation). To fix:
-
-1. Stop the server
-2. Delete the database: `rm {DATA_DIR}/data.db`
-3. Start the server and register again
-
-This resets all data. Use only on fresh installations.
+Workspaces are visible only to their members (the org Super Admin sees all workspaces in their org). If a teammate created a workspace in *their* organization, they must invite you — registering your own account creates a separate organization with its own workspaces.
 
 ### "Seat limit reached" when inviting a member
 

--- a/configuration/workspace-config.md
+++ b/configuration/workspace-config.md
@@ -1,117 +1,96 @@
 ---
 title: Workspace Settings
-description: Configure workspace-level settings — git remote, theme, navigation order, publishing defaults, and more.
+description: Configure workspace-level settings — git remote, theme, navigation, publishing overlay, and the .docplatform manifest files.
 ---
 
 # Workspace Settings
 
-Each workspace has its own configuration file at `.docplatform/workspaces/{workspace-id}/.docplatform/config.yaml`. Edit this file directly or use the web UI (**Settings** → **Workspace**).
+Workspace settings live in two places:
 
-## Full configuration reference
+1. **The database** — identity, git connection, and permission settings, edited through the web UI (**Settings** gear icon) or the REST API. These are not stored in a config file.
+2. **Manifest files** under `.docplatform/` in the workspace's content directory — display and publishing configuration that versions alongside your content and flows through git sync like any other file.
 
-```yaml
-# Workspace identity
-workspace_id: 01KJJ10NTF31Z1QJTG4ZRQZ2Z2    # Auto-generated ULID
-name: "Engineering Docs"                        # Display name
-slug: eng-docs                                  # URL slug for published docs
-description: "Internal engineering documentation"
+## Database-backed settings
 
-# Git synchronization
-git_remote: git@github.com:your-org/eng-docs.git
-git_branch: main
-git_auto_commit: true       # Auto-commit editor saves to git
-sync_interval: 300          # Polling interval in seconds (0 = disabled)
+Edited via **Settings** in the web UI, or `PATCH /api/v1/workspaces/:id`:
 
-# Theme
-theme:
-  mode: auto                # light, dark, auto (follows system preference)
-  accent: blue              # Accent color for published site
-
-# Publishing defaults
-publishing:
-  default_published: false  # New pages published by default?
-  require_explicit_unpublish: false
-
-# Permissions
-permissions:
-  default_role: viewer      # Role assigned to new workspace members
-
-# Navigation (for published docs sidebar)
-navigation:
-  - title: "Overview"
-    path: "index.md"
-  - title: "Getting Started"
-    path: "getting-started/index.md"
-    children:
-      - title: "Installation"
-        path: "getting-started/installation.md"
-      - title: "Configuration"
-        path: "getting-started/configuration.md"
-```
-
-## Settings reference
-
-### Identity
-
-| Key | Type | Description |
-|---|---|---|
-| `workspace_id` | string | ULID auto-generated at creation. Do not change. |
-| `name` | string | Display name shown in the UI and published site header |
-| `slug` | string | URL segment for published docs: `/p/{slug}/`. Changing this breaks existing URLs. |
-| `description` | string | Optional description for internal reference |
-
-### Git
-
-| Key | Type | Default | Description |
+| Setting | Type | Default | Description |
 |---|---|---|---|
+| `name` | string | — | Display name shown in the UI and published site header |
+| `slug` | string | — | URL segment for published docs: `/p/{slug}/`. Changing this breaks existing URLs. |
+| `description` | string | — | Optional description for internal reference |
 | `git_remote` | string | — | Remote repository URL (SSH or HTTPS) |
 | `git_branch` | string | `main` | Branch to sync with |
-| `git_auto_commit` | bool | `true` | Auto-commit saves from the web editor |
-| `sync_interval` | int | `300` | Seconds between polling the remote. Set to `0` to disable polling (webhook-only). |
+| `git_auto_commit` | bool | `true` | Auto-commit saves from the web editor (requires a git remote) |
+| `sync_interval` | int | `300` | Seconds between polling the remote (minimum 10) |
+| `editor_can_create_pages` | bool | `true` | Whether Editors may create pages |
+| `editor_can_delete_pages` | bool | `false` | Whether Editors may delete pages |
 
-### Theme
+The published site has its own settings — theme (7 built-in themes), visibility (`authenticated` or `public`), navigation groups, and custom domain — managed under **Settings → Publishing** (`PUT /api/v1/workspaces/:id/admin/settings`). See the [Publishing guide](../guides/publishing.md).
 
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `theme.mode` | string | `auto` | Color scheme for published docs: `light`, `dark`, `auto` |
-| `theme.accent` | string | `blue` | Accent color used in published docs for links, buttons, and highlights |
+## Manifest files (`.docplatform/`)
 
-### Publishing
+Each workspace's content directory contains a `.docplatform/` folder with up to four YAML manifests. Because they are regular files in the git tree, you can edit them from your IDE and push — changes are picked up on the next sync.
 
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `publishing.default_published` | bool | `false` | Whether new pages are published by default |
-| `publishing.require_explicit_unpublish` | bool | `false` | When true, pages must be explicitly unpublished (prevents accidental exclusion) |
+| File | Purpose |
+|---|---|
+| `workspace.yaml` | Display settings: name, description, published-site theme, custom CSS, editor defaults |
+| `publish.yaml` | Publishing overlay: per-path publish decisions, landing page, SEO and robots settings |
+| `nav.yaml` | Published-site sidebar navigation tree |
+| `redirects.yaml` | URL redirects for the published site |
 
-### Permissions
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `permissions.default_role` | string | `viewer` | Role assigned to users who accept a workspace invitation |
-
-### Navigation
-
-The `navigation` array controls the sidebar order in published docs. Without it, pages are ordered alphabetically.
+### `workspace.yaml`
 
 ```yaml
-navigation:
-  - title: "Overview"       # Display label
-    path: "index.md"        # File path relative to docs/
-  - title: "Guides"         # Section header (no path = non-clickable group)
-    children:
-      - title: "Editor"
-        path: "guides/editor.md"
-      - title: "Git Sync"
-        path: "guides/git-integration.md"
+version: 1
+name: "Engineering Docs"
+description: "Internal engineering documentation"
+theme: default              # one of the 7 built-in themes
+custom_css_path: ""         # optional path to a custom stylesheet
+editor_defaults:
+  collapse_sidebar: false
+  show_line_numbers_in_code: false
 ```
 
-**Rules:**
+### `publish.yaml`
 
-- Each entry needs a `title`
-- Entries with a `path` are page links
-- Entries without a `path` but with `children` are section headers
-- Nesting depth is unlimited
-- Pages not listed in `navigation` still exist but don't appear in the sidebar
+The publish overlay has the **final say** on whether a page appears on the published site — an entry here overrides the page's frontmatter `publish:` flag. A malformed overlay never knocks pages offline; DocPlatform logs the problem and falls back to frontmatter.
+
+```yaml
+version: 1
+landing:
+  mode: page                # what / serves: a page or custom markdown
+  page: index.md
+pages:
+  - path: internal/draft.md
+    public: false           # overrides frontmatter publish: true
+  - path: announcements/launch.md
+    public: true
+```
+
+### `nav.yaml`
+
+Controls the published-site sidebar. Without it, navigation is derived from the page tree.
+
+```yaml
+version: 1
+tree:
+  - file: index.md
+  - section: "Guides"
+    collapsed: false
+    children:
+      - file: guides/editor.md
+      - file: guides/git-integration.md
+  - heading: "Resources"
+  - link: "Status page"
+    url: https://status.example.com
+```
+
+Node types: `file` (a page link), `section` (a collapsible group with `children`), `heading` (a non-clickable label), and `link`/`url` (an external link).
+
+### Conflict behavior during git sync
+
+If both the web editor and a git push change the same manifest, DocPlatform three-way-merges `workspace.yaml`, `publish.yaml`, and `redirects.yaml` automatically. Conflicts in `nav.yaml` — and in **all** Markdown pages — are never auto-merged; they are surfaced for a human to resolve. See [Git Integration](../guides/git-integration.md).
 
 ## Editing settings
 
@@ -119,31 +98,11 @@ navigation:
 
 1. Open the workspace in the web editor
 2. Click **Settings** (gear icon)
-3. Modify settings through the form interface
-4. Changes save automatically
-
-### Via config file
-
-Edit the YAML file directly:
-
-```bash
-# Find your workspace config
-ls .docplatform/workspaces/*/. docplatform/config.yaml
-
-# Edit
-nano .docplatform/workspaces/01KJJ.../. docplatform/config.yaml
-```
-
-Restart the server for changes to take effect, or trigger a reload via the API:
-
-```bash
-curl -X POST http://localhost:3000/api/v1/admin/reload \
-  -H "Authorization: Bearer {token}"
-```
+3. Modify settings through the form interface — changes apply immediately
 
 ### Via git
 
-If the workspace config file is tracked in git, push changes from your IDE and they'll be picked up on the next sync cycle. This is useful for managing documentation configuration as code.
+Edit the `.docplatform/` manifests from your IDE and push. They're picked up on the next sync cycle — useful for managing documentation configuration as code, with publish decisions visible in code review.
 
 ## Multiple workspaces
 
@@ -152,16 +111,7 @@ DocPlatform supports multiple workspaces on a single instance. Each workspace is
 - Separate content directories
 - Separate git repositories
 - Separate member lists and roles
-- Separate search indexes
+- Search results scoped per workspace
 - Separate published sites (different slugs)
 
-Create additional workspaces via CLI:
-
-```bash
-docplatform init \
-  --workspace-name "API Docs" \
-  --slug api-docs \
-  --git-url git@github.com:your-org/api-docs.git
-```
-
-Or via the web UI workspace switcher.
+Create additional workspaces from the web UI workspace switcher (org Super Admin).

--- a/deployment/binary.md
+++ b/deployment/binary.md
@@ -21,7 +21,7 @@ chmod +x docplatform-linux-amd64
 sudo mv docplatform-linux-amd64 /usr/local/bin/docplatform
 
 # Or download a specific version
-curl -sLO https://github.com/Valoryx-org/releases/releases/download/v0.5.2/docplatform-linux-amd64
+curl -sLO https://github.com/Valoryx-org/releases/releases/download/v0.10.0/docplatform-linux-amd64
 ```
 
 Available platforms:
@@ -38,11 +38,11 @@ Archives (with version):
 
 | OS | Architecture | Archive |
 |---|---|---|
-| Linux | amd64 | `docplatform_0.5.2_linux_amd64.tar.gz` |
-| Linux | arm64 | `docplatform_0.5.2_linux_arm64.tar.gz` |
-| macOS | amd64 (Intel) | `docplatform_0.5.2_darwin_amd64.tar.gz` |
-| macOS | arm64 (Apple Silicon) | `docplatform_0.5.2_darwin_arm64.tar.gz` |
-| Windows | amd64 | `docplatform_0.5.2_windows_amd64.zip` |
+| Linux | amd64 | `docplatform_0.10.0_linux_amd64.tar.gz` |
+| Linux | arm64 | `docplatform_0.10.0_linux_arm64.tar.gz` |
+| macOS | amd64 (Intel) | `docplatform_0.10.0_darwin_amd64.tar.gz` |
+| macOS | arm64 (Apple Silicon) | `docplatform_0.10.0_darwin_arm64.tar.gz` |
+| Windows | amd64 | `docplatform_0.10.0_windows_amd64.zip` |
 
 ### Verify the download
 
@@ -66,7 +66,7 @@ Verify:
 
 ```bash
 docplatform version
-# docplatform v0.5.2 (commit: abc1234, built: 2026-03-08T10:00:00Z)
+# docplatform v0.10.0 (commit: 5738520, built: 2026-05-16T17:52:38Z)
 ```
 
 ## Initialize
@@ -91,6 +91,8 @@ docplatform init \
   --git-url git@github.com:your-org/docs.git \
   --branch main
 ```
+
+> `docplatform init` is optional — the server initializes its database on first run, and registering through the web UI creates a starter workspace. CLI-created workspaces belong to a server-level default organization, not to web accounts (see [Your First Workspace](../getting-started/first-workspace.md)); for most deployments, create workspaces through the web UI after registering.
 
 ## Configure
 
@@ -217,24 +219,26 @@ server {
 }
 ```
 
-When using a reverse proxy, set `HOST=127.0.0.1` so DocPlatform only listens on localhost.
+DocPlatform listens on all interfaces on `PORT` (there is no listen-address setting). When running behind a reverse proxy, use your firewall to block external access to port 3000 so only the proxy can reach it.
 
 ## Upgrades
 
-```bash
-# Download new version (recommended)
-curl -fsSL https://valoryx.org/install.sh | sh
+**Stop the service before replacing the binary** — overwriting a running binary fails on Linux with "Text file busy":
 
-# Or download manually
+```bash
+# 1. Stop
+sudo systemctl stop docplatform
+
+# 2. Download the new version
 curl -sLO https://github.com/Valoryx-org/releases/releases/latest/download/docplatform-linux-amd64
 chmod +x docplatform-linux-amd64
 sudo mv docplatform-linux-amd64 /usr/local/bin/docplatform
 
-# Restart
-sudo systemctl restart docplatform
+# 3. Start
+sudo systemctl start docplatform
 ```
 
-Database migrations run automatically on startup. Backups are created before migration if `BACKUP_ENABLED=true`.
+Database migrations run automatically on startup. Keep `BACKUP_ENABLED=true` (the default) so daily backups are available if you need to roll back.
 
 ## Rollback
 

--- a/deployment/docker.md
+++ b/deployment/docker.md
@@ -72,8 +72,7 @@ docker compose up -d
 | Tag | Description |
 |---|---|
 | `latest` | Most recent stable release |
-| `v0.5.2` | Specific version |
-| `v0.5` | Latest patch for v0.5.x |
+| `v0.10.0` | Specific version |
 
 ## Volumes
 
@@ -88,14 +87,14 @@ The `/data` directory contains:
 ```
 /data/
 ├── data.db              # SQLite database
-├── jwt-private.pem          # Auto-generated RS256 signing key
+├── analytics.db         # Analytics database
+├── jwt-private.pem      # Auto-generated RS256 signing key
+├── search-index/        # Full-text search index
 ├── backups/             # Daily backup files
 └── workspaces/
-    └── {workspace-id}/
-        ├── docs/        # Markdown files
+    └── {workspace-id}/  # Markdown files (the git working tree)
         ├── .git/        # Git repository (if connected)
-        └── .docplatform/
-            └── config.yaml
+        └── .docplatform/   # workspace.yaml, publish.yaml, nav.yaml, redirects.yaml
 ```
 
 **Do not skip the volume mount.** Without it, all data is lost when the container is removed.
@@ -171,7 +170,6 @@ services:
       - docplatform-data:/data
     environment:
       - DATA_DIR=/data
-      - HOST=0.0.0.0
     restart: unless-stopped
 
   caddy:
@@ -224,20 +222,6 @@ docker run -d \
 ```
 
 Data in the volume persists across container recreations.
-
-## Build from source
-
-Build your own image from the Dockerfile:
-
-```bash
-cd docplatform
-docker build -t docplatform:custom .
-```
-
-The Dockerfile uses a 2-stage build:
-
-1. **Build stage** — Go compilation with CGO disabled (static frontend assets are embedded at compile time)
-2. **Runtime stage** — Alpine Linux with the compiled binary
 
 ## Logs
 

--- a/deployment/production.md
+++ b/deployment/production.md
@@ -22,8 +22,10 @@ These items are necessary for a secure, reliable production deployment.
 
 - [ ] **TLS enabled** — Run behind a reverse proxy (Caddy, nginx, cloud load balancer) with HTTPS. DocPlatform does not terminate TLS itself.
 - [ ] **JWT key secured** — The `jwt-private.pem` file grants the ability to forge authentication tokens. Restrict filesystem permissions: `chmod 600`.
-- [ ] **First user registered** — The first registered user becomes Super Admin. Register your admin account before opening the server to others.
-- [ ] **Bind to localhost** — If using a reverse proxy on the same host, set `HOST=127.0.0.1` so DocPlatform isn't directly accessible.
+- [ ] **Production mode enabled** — Set `DOCPLATFORM_ENV=production` to turn on strict configuration validation.
+- [ ] **API key pepper set** — `API_KEY_PEPPER` is required in production mode; it strengthens API-key hashing.
+- [ ] **Git token encryption key set** — If you'll connect git providers with access tokens, set `GIT_ENCRYPTION_KEY` (min 16 chars) so tokens are encrypted at rest.
+- [ ] **Firewall the app port** — If using a reverse proxy on the same host, block external access to port 3000 so DocPlatform is only reachable through the proxy (there is no listen-address setting).
 
 ### Backups
 
@@ -91,20 +93,19 @@ If you need to scale beyond these limits, future editions will support multi-ins
 ### Network
 
 - Run behind a reverse proxy with TLS
-- Set `HOST=127.0.0.1` to block direct access
-- Use firewall rules to restrict access to the server
+- Use firewall rules so only the reverse proxy can reach the app port
 - **WebSocket proxy** — ensure your reverse proxy supports WebSocket upgrade. Without it, real-time presence and live updates won't work. Both Caddy and nginx (with `proxy_http_version 1.1` and `Upgrade` headers) support this.
 
 ### Response headers
 
-DocPlatform sets security headers automatically on all responses:
+DocPlatform sets security headers automatically:
 
 | Header | Value |
 |---|---|
 | `X-Content-Type-Options` | `nosniff` |
-| `X-Frame-Options` | `DENY` |
-| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'` |
-| `X-Request-ID` | ULID (unique per request) |
+| `Content-Security-Policy` | Set per surface (API, published sites, and the SPA each get an appropriate nonce-based policy) |
+
+`HSTS` and `X-Frame-Options` are intentionally left to the reverse proxy — configure them there (Caddy and nginx both make this a one-liner).
 
 ### Filesystem
 
@@ -115,8 +116,8 @@ DocPlatform sets security headers automatically on all responses:
 ### Authentication
 
 - Enable OIDC to reduce locally-stored credentials
-- Use strong passwords (DocPlatform uses argon2id — resistant to brute force)
-- Review active sessions periodically (Admin panel → Users → Sessions)
+- Use strong passwords (DocPlatform uses argon2id — resistant to brute force; repeated failures trigger a 15-minute lockout)
+- Have users review their active sessions periodically (Profile → Sessions)
 
 ### Updates
 
@@ -135,27 +136,24 @@ sudo useradd -r -s /sbin/nologin docplatform
 sudo mkdir -p /var/lib/docplatform
 sudo chown docplatform:docplatform /var/lib/docplatform
 
-# 3. Initialize workspace
-cd /var/lib/docplatform
-sudo -u docplatform docplatform init \
-  --workspace-name "Docs" \
-  --slug docs
-
-# 4. Configure environment
+# 3. Configure environment
 sudo mkdir -p /etc/docplatform
 sudo tee /etc/docplatform/.env <<EOF
 PORT=3000
-HOST=127.0.0.1
 DATA_DIR=/var/lib/docplatform
+DOCPLATFORM_ENV=production
+API_KEY_PEPPER=$(openssl rand -hex 32)
 BACKUP_RETENTION_DAYS=30
 EOF
+sudo chmod 600 /etc/docplatform/.env
 
-# 5. Create systemd service (see Binary Deployment guide)
-# 6. Set up reverse proxy with TLS (see Binary Deployment guide)
+# 4. Create systemd service (see Binary Deployment guide)
+# 5. Set up reverse proxy with TLS (see Binary Deployment guide)
 
-# 7. Start and verify
+# 6. Start and verify
 sudo systemctl enable --now docplatform
 docplatform doctor
 
-# 8. Register admin account at https://docs.yourcompany.com
+# 7. Register your account at https://docs.yourcompany.com
+#    (registration creates your organization + starter workspace)
 ```

--- a/getting-started/first-workspace.md
+++ b/getting-started/first-workspace.md
@@ -18,6 +18,14 @@ A workspace is the top-level container for a documentation project. Each workspa
 
 ## Create a workspace
 
+### Via web UI (recommended)
+
+1. Sign in as your organization's Super Admin
+2. Open the workspace switcher (top-left dropdown)
+3. Click **Create Workspace**
+4. Enter a name and slug
+5. Optionally configure a git remote
+
 ### Via CLI
 
 ```bash
@@ -26,13 +34,7 @@ docplatform init \
   --slug eng-docs
 ```
 
-### Via web UI
-
-1. Sign in as Super Admin or Admin
-2. Open the workspace switcher (top-left dropdown)
-3. Click **Create Workspace**
-4. Enter a name and slug
-5. Optionally configure a git remote
+> **Note:** `docplatform init` attaches the workspace to a server-level *default organization*, not to any web account's organization. Use it for headless/bootstrap scenarios (e.g., pre-cloning a git repo before first run). For day-to-day use, create workspaces from the web UI so they belong to your organization.
 
 ## Connect a git repository
 
@@ -50,16 +52,7 @@ docplatform init \
 
 ### After creation
 
-Update the workspace config at `.docplatform/workspaces/{id}/.docplatform/config.yaml`:
-
-```yaml
-git_remote: git@github.com:your-org/eng-docs.git
-git_branch: main
-git_auto_commit: true
-sync_interval: 300  # seconds
-```
-
-Then restart the server or trigger a manual sync from the web UI.
+Connect a repository from the web UI: **Workspace Settings → Git**. Validate a GitHub personal access token, pick the repository and branch, and DocPlatform stores the connection (the token is encrypted at rest with AES-256-GCM). Git settings — remote, branch, auto-commit, and sync interval — live in the workspace record and can be changed there at any time; no server restart is required.
 
 ### SSH key setup
 
@@ -100,10 +93,10 @@ export GIT_SSH_KEY_PATH=~/.ssh/docplatform_deploy_key
 
 ### Page hierarchy
 
-Pages can be nested to any depth. The file structure in `docs/` maps directly to the URL structure:
+Pages can be nested to any depth. The file structure in the workspace directory maps directly to the URL structure:
 
 ```
-docs/
+(workspace root)
 ├── index.md                → /p/eng-docs/
 ├── getting-started.md      → /p/eng-docs/getting-started
 ├── api/
@@ -124,14 +117,13 @@ Every page starts with YAML frontmatter:
 title: Authentication
 description: How to authenticate with the API using JWT tokens.
 tags: [api, auth, jwt]
-published: true
-access:
-  read: []            # empty = all workspace members (default)
-  write: []           # restrict by role name or @user_id
+publish: true         # include this page on the published site
+status: draft         # optional editorial status
+nav_order: 2          # optional ordering hint for sidebar navigation
 ---
 ```
 
-The `title` is required. All other fields are optional and have sensible defaults.
+The `title` is required. All other fields are optional. `tags` accepts either a YAML list or a comma-separated string. An `access` block is parsed and preserved if present, but per-page access control is **not enforced** — permissions are role-based at the workspace level.
 
 ## Invite your team
 
@@ -159,7 +151,7 @@ For detailed permission configuration, see [Roles & Permissions](../configuratio
 
 ## Workspace settings
 
-Access workspace settings through the web UI (**Settings** gear icon) or by editing the config file directly.
+Access workspace settings through the web UI (**Settings** gear icon).
 
 Key settings:
 
@@ -171,9 +163,8 @@ Key settings:
 | `git_branch` | Branch to sync | `main` |
 | `git_auto_commit` | Auto-commit editor saves | `true` |
 | `sync_interval` | Git polling interval (seconds) | `300` |
-| `theme.mode` | Color scheme: `light`, `dark`, `auto` | `auto` |
-| `theme.accent` | Accent color | `blue` |
-| `permissions.default_role` | Role for new members | `viewer` |
+| `theme` | Published-site theme (7 available) | `default` |
+| `visibility` | Published-site access: `authenticated` or `public` | `authenticated` |
 
 For the complete configuration reference, see [Workspace Settings](../configuration/workspace-config.md).
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -23,7 +23,7 @@ DocPlatform has no external dependencies. You don't need to install a database, 
 
 - **Git 2.30+** — only required if you want to sync with a remote git repository
 - **SSH key** — only required for private git repos over SSH
-- **SMTP server** — only required for email invitations and password reset (without SMTP, reset tokens print to stdout)
+- **Email provider (SMTP or Resend)** — only required for email invitations and password reset (without email configured, reset links are printed to the server log; admins can also generate them with `docplatform reset-password`)
 
 ## Architecture at a glance
 

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -29,7 +29,7 @@ docplatform version
 **Expected output:**
 
 ```
-docplatform v0.5.2 (commit: abc1234, built: 2026-03-08T10:00:00Z)
+docplatform v0.10.0 (commit: 5738520, built: 2026-05-16T17:52:38Z)
 ```
 
 ### Windows
@@ -104,42 +104,9 @@ docker compose up -d
 
 For production Docker deployments, see the [Docker deployment guide](../deployment/docker.md).
 
-## Option 3: Build from source
+## A note on source code
 
-Build from source if you want to contribute or run a development version.
-
-**Prerequisites:**
-
-- Go 1.26+
-- Node.js 20+ (frontend assets are pre-built; no pnpm required)
-- Git
-- Make
-
-```bash
-# Clone the repository
-git clone https://github.com/Valoryx-org/docplatform.git
-cd docplatform
-
-# Build the binary (compiles Go + embeds static frontend assets)
-make build
-
-# Verify
-./docplatform version
-```
-
-### Development mode
-
-For hot-reloading during development:
-
-```bash
-# Simple run (no hot reload)
-make dev
-
-# Go hot reload with air
-make dev-hot
-```
-
-`make dev` starts the server for development. `make dev-hot` starts the Go server with hot reload via air and the Vite dev server with HMR.
+DocPlatform is proprietary software distributed as pre-built binaries and container images only. The source code is not publicly available, so there is no build-from-source installation path. Community Edition is free of charge and fully functional — see [Community Edition limits](../index.md#community-edition-limits).
 
 ## Next steps
 

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -30,64 +30,43 @@ docker run -d --name docplatform -p 3000:3000 -v docplatform-data:/data ghcr.io/
 
 If using Docker, skip to [Step 3](#step-3-register-your-account) — the container auto-initializes.
 
-## Step 2: Initialize a workspace
-
-```bash
-docplatform init --workspace-name "My Docs" --slug my-docs
-```
-
-This creates:
-
-```
-.docplatform/
-├── data.db              # SQLite database
-├── jwt-private.pem      # Auto-generated RS256 signing key
-└── workspaces/
-    └── {workspace-id}/
-        ├── docs/        # Your documentation lives here
-        └── .docplatform/
-            └── config.yaml
-```
-
-### With git (optional)
-
-Connect to an existing git repository during initialization:
-
-```bash
-docplatform init \
-  --workspace-name "My Docs" \
-  --slug my-docs \
-  --git-url git@github.com:your-org/docs.git \
-  --branch main
-```
-
-DocPlatform clones the repository and begins syncing. Any existing `.md` files are automatically indexed.
-
-## Step 3: Start the server
+## Step 2: Start the server
 
 ```bash
 docplatform serve
 ```
 
 ```
-INFO  Server starting            addr=:3000 version=v0.5.2
+INFO  Server starting            addr=:3000 version=v0.10.0
 INFO  Database initialized       path=.docplatform/data.db
 INFO  Search index ready         documents=0
-INFO  Workspace loaded           name="My Docs" slug=my-docs
 INFO  Listening on               http://localhost:3000
+```
+
+On first run, DocPlatform creates its data directory:
+
+```
+.docplatform/
+├── data.db              # SQLite database
+├── analytics.db         # Analytics database (separate file)
+├── jwt-private.pem      # Auto-generated RS256 signing key
+├── search-index/        # Embedded full-text search index
+└── workspaces/          # One directory per workspace — your .md files live here
 ```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-## Step 4: Register your account
-
-The first user to register automatically becomes the **Super Admin** with full platform access.
+## Step 3: Register your account
 
 1. Click **Create Account**
 2. Enter your name, email, and password
 3. You're signed in and ready to write
 
-> **Security note:** The first-user-becomes-admin flow only applies when no users exist. After the first registration, new accounts get the default role configured for the workspace.
+Registering creates your own **organization** — you are its **Super Admin** — along with a starter workspace pre-loaded with example content, so you can begin writing immediately.
+
+## Step 4: Connect git (optional)
+
+To back your workspace with a git repository, open **Workspace Settings → Git** in the web UI, connect with a GitHub personal access token, and pick the repository and branch. Existing `.md` files are pulled in and indexed automatically. See the [Git Integration guide](../guides/git-integration.md) for details.
 
 ## Step 5: Create your first page
 
@@ -96,7 +75,7 @@ The first user to register automatically becomes the **Super Admin** with full p
 3. Start writing in the rich editor
 4. Changes autosave every few seconds
 
-The page is stored as a Markdown file in your workspace's `docs/` directory. If you connected git, it auto-commits and pushes.
+The page is stored as a Markdown file in your workspace's directory under `.docplatform/workspaces/`. If you connected git, it auto-commits and pushes.
 
 ## Step 6: Try it out
 
@@ -107,7 +86,7 @@ Here are a few things to try right away:
 | **Switch to raw Markdown** | Click the `</>` toggle in the editor toolbar |
 | **Search** | Press `Cmd+K` (or `Ctrl+K`) to open instant search |
 | **Create a sub-page** | Click the `+` next to an existing page in the sidebar |
-| **Preview published site** | Navigate to `http://localhost:3000/p/my-docs/` |
+| **Publish your docs** | Enable publishing in **Workspace Settings → Publishing**, then visit `http://localhost:3000/p/{your-slug}/` |
 | **Run diagnostics** | Run `docplatform doctor` in your terminal |
 
 ## What's next

--- a/guides/ai-features.md
+++ b/guides/ai-features.md
@@ -18,16 +18,16 @@ AI_API_KEY=sk-ant-...     # your API key
 AI_MODEL=                 # optional — uses provider default if empty
 ```
 
-Restart the server. AI features appear in the editor toolbar and are accessible via the API.
+Restart the server. AI features become available through the REST API and the MCP server's `docplatform_writing_assist` tool.
 
 ### Supported providers
 
-| Provider | Variable | Default model |
+| Provider | Variable | Model |
 |---|---|---|
-| **Anthropic** (Claude) | `AI_PROVIDER=anthropic` | Claude Sonnet 4.5 (claude-sonnet-4-5-20250514) |
-| **OpenAI** | `AI_PROVIDER=openai` | GPT-4o |
+| **Anthropic** (Claude) | `AI_PROVIDER=anthropic` (default) | Provider default, or set `AI_MODEL` |
+| **OpenAI** | `AI_PROVIDER=openai` | Provider default, or set `AI_MODEL` |
 
-Override the model with `AI_MODEL` (e.g., `claude-opus-4-6`, `gpt-4-turbo`).
+Override the model with `AI_MODEL` (e.g., `claude-sonnet-4-6`, `gpt-4o`).
 
 ### Check AI status
 
@@ -39,7 +39,7 @@ Returns whether AI is enabled and which provider is configured.
 
 ## Writing assist
 
-Select text in the editor and use the AI toolbar to transform it:
+Transform text with six operations, via the REST API or the `docplatform_writing_assist` MCP tool (there is no AI toolbar in the editor today):
 
 | Operation | Description |
 |---|---|
@@ -58,13 +58,13 @@ POST /api/v1/ai/writing-assist
 
 ```json
 {
-  "workspace_id": "01HJK...",
-  "operation": "improve",
-  "content": "This is the text to improve."
+  "action": "improve",
+  "content": "This is the text to improve.",
+  "language": "de"
 }
 ```
 
-**Operations:** `improve`, `simplify`, `expand`, `summarize`, `fix_grammar`, `translate`
+**Actions:** `improve`, `simplify`, `expand`, `summarize`, `fix_grammar`, `translate` (only `translate` uses `language`). Unknown actions are rejected with a validation error.
 
 **Response:**
 
@@ -76,17 +76,7 @@ POST /api/v1/ai/writing-assist
 
 ## Doc chat
 
-Ask questions about your workspace documentation and get context-aware answers.
-
-### In the editor
-
-Click the **Chat** button in the sidebar to open the doc chat panel. Ask questions like:
-
-- "How do I configure git sync?"
-- "What authentication methods are supported?"
-- "Summarize the deployment guide"
-
-The AI searches your workspace content and provides answers grounded in your actual documentation.
+Ask questions about your workspace documentation and get context-aware answers. Doc chat is an **API capability** — there is no chat panel in the editor UI today. Use it from your own integrations, or point an AI agent at the [MCP server](mcp.md) for an interactive equivalent (`docplatform_search` + `docplatform_get_context`).
 
 ### API usage
 
@@ -107,7 +97,7 @@ Supports multi-turn conversations — include previous messages in the `messages
 
 ## MCP server
 
-DocPlatform includes a built-in Model Context Protocol (MCP) server with **24 tools**, allowing AI agents like Claude Code, Claude Desktop, or Cursor to read, write, search, and manage your documentation directly.
+DocPlatform includes a built-in Model Context Protocol (MCP) server with **26 tools**, allowing AI agents like Claude Code, Claude Desktop, or Cursor to read, write, search, and manage your documentation directly.
 
 ### Quick setup
 
@@ -151,7 +141,7 @@ claude mcp add docplatform -- docplatform mcp --workspace my-docs --api-key dp_l
 
 ### Tool categories
 
-The 24 MCP tools cover content CRUD (6), discovery & RAG (5), quality (2), settings (2), workspace management (2), versioning (2), export (1), AI writing (1), activity (1), and comments (2).
+The 26 MCP tools cover content CRUD (6), discovery & RAG (5), quality (2), settings (2), workspace management (3), versioning (2), export (1), AI writing (1), activity (1), comments (2), and sync conflict resolution (1, conditional).
 
 Key highlights:
 

--- a/guides/analytics.md
+++ b/guides/analytics.md
@@ -22,10 +22,11 @@ Analytics data is collected in a separate `analytics.db` SQLite database (not in
 
 ### What is NOT tracked
 
-- IP addresses (never stored)
-- User agents are not stored
+- Raw IP addresses are never stored (consent records keep only a salted SHA-256 hash — set `DOCPLATFORM_IP_SALT` in production)
 - Cookies or cross-session identifiers (without consent)
 - Personally identifiable information
+
+Visitors with **Do-Not-Track** enabled are never tracked, regardless of consent.
 
 ## GDPR compliance
 
@@ -61,7 +62,7 @@ Returns the most-viewed pages in the workspace over the specified time period.
     { "path": "guides/git-integration.md", "views": 892 },
     { "path": "reference/api.md", "views": 567 }
   ],
-  "period_days": 30
+  "days": 30
 }
 ```
 
@@ -80,7 +81,7 @@ Returns the most popular search queries.
     { "query": "authentication", "count": 32 },
     { "query": "docker deploy", "count": 18 }
   ],
-  "period_days": 30
+  "days": 30
 }
 ```
 
@@ -92,18 +93,17 @@ GET /api/v1/workspaces/:id/analytics/overview
 
 Returns a summary dashboard with total views, total searches, and unique pages viewed.
 
-## Platform analytics (Super Admin)
-
-Super admins can view platform-wide analytics across all organizations:
-
-```
-GET /api/admin/analytics/overview  — Total platform traffic
-GET /api/admin/analytics/growth    — Growth metrics over time
-```
-
 ## Feature gating
 
-Analytics is available on paid plans (Team, Business). Community Edition users see the analytics UI but data collection is disabled.
+Analytics **reporting** is gated by plan feature, not edition:
+
+| Edition / plan | Analytics |
+|---|---|
+| **Community Edition** (self-hosted) | ✔ Included, unlimited |
+| **Cloud Free** | ✘ Not included |
+| **Cloud Team / Business** | ✔ Included |
+
+Pageview **collection** itself is consent-based and not plan-gated — if an org later upgrades, history recorded under consent is already there. On plans without analytics, the reporting endpoints return `403 PLAN_LIMIT`.
 
 ## Configuration
 

--- a/guides/billing.md
+++ b/guides/billing.md
@@ -5,21 +5,25 @@ description: Configure Stripe billing, understand plan tiers, feature gating, an
 
 # Billing & Plans
 
-DocPlatform uses Stripe for subscription billing. Three plan tiers are available, each with different limits and features.
+> **Cloud edition only.** Billing applies to **DocPlatform Cloud** ([app.valoryx.dev](https://app.valoryx.dev)). The self-hosted Community Edition contains no billing code at all — it is free forever and unlimited, and nothing on this page applies to it.
+
+DocPlatform Cloud uses Stripe for subscription billing across three cloud tiers: Free, Team, and Business.
 
 ## Plans
 
-| Feature | Community (Free) | Free | Team ($29/mo) | Business ($79/mo) |
+| Feature | Community (self-hosted) | Cloud Free | Cloud Team ($29/mo) | Cloud Business ($79/mo) |
 |---|---|---|---|---|
-| **Editors** | Unlimited | 3 | 15 | 50 |
+| **Editor seats** (Editor + Admin roles) | Unlimited | 3 | 15 | 50 |
 | **Workspaces** | Unlimited | 1 | 3 | 10 |
 | **Viewers / Commenters** | Unlimited | Unlimited | Unlimited | Unlimited |
-| **Pages** | Unlimited | 50 | 150 | Unlimited |
+| **Pages per workspace** | Unlimited | 50 | 150 | Unlimited |
 | **Published docs** | Unlimited | Unlimited | Unlimited | Unlimited |
-| **Analytics** | — | — | Included | Included |
-| **Custom domains** | — | — | Included | Included |
-| **Advanced AI** | — | — | Included | Included |
+| **Analytics** | Included | — | Included | Included |
+| **Custom domains** | Included | — | Included | Included |
+| **"Powered by Valoryx" badge** | Always shown | Always shown | Hidden by default (opt-in to show) | Hidden by default (opt-in to show) |
 | **Priority support** | — | — | — | Included |
+
+> "Community Edition" and the cloud "Free tier" are different things: Community is the unlimited self-hosted binary; Free is the restricted $0 tier of the hosted cloud service.
 
 ### Annual pricing
 
@@ -32,15 +36,11 @@ Annual subscriptions include 2 months free:
 
 ### Free trial
 
-New organizations get a **14-day free trial** of the Team plan. During the trial:
+Paid subscriptions start with a **14-day free trial** — all plan features are available during the trial. If the trial ends without an active subscription, the organization enters a grace period and then reverts to **Free tier** limits.
 
-- All Team features are available
-- No credit card required to start
-- At trial end, the organization reverts to Community Edition limits
+## Setup (Cloud operators)
 
-The trial duration is configurable via `TRIAL_DURATION_DAYS`.
-
-## Setup
+This section documents how the Cloud edition's billing is configured server-side. It is informational for Cloud customers — these variables only exist in the cloud binary.
 
 ### Prerequisites
 
@@ -49,10 +49,7 @@ The trial duration is configurable via `TRIAL_DURATION_DAYS`.
 
 ### Configuration
 
-Set the following environment variables:
-
 ```bash
-# .env
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 
@@ -89,7 +86,7 @@ DocPlatform handles all webhook events idempotently — duplicate deliveries are
 
 ### Disabling billing
 
-Set `FF_BILLING=false` to disable billing entirely. All organizations are treated as having unlimited features (useful for self-hosted single-tenant deployments).
+Set `FF_BILLING=false` to disable billing enforcement entirely on a cloud binary — all organizations are treated as unlimited. (Self-hosters don't need this: the Community Edition has no billing to disable.)
 
 ## User experience
 
@@ -121,55 +118,42 @@ Creates a Stripe Customer Portal session where users can:
 GET /api/v1/billing/limits
 ```
 
-Returns current plan limits and usage:
+Returns current plan limits and usage (`null` limits mean unlimited):
 
 ```json
 {
-  "plan": "team",
-  "limits": {
-    "max_editors": 15,
-    "max_workspaces": 3,
-    "features": ["analytics", "custom_domains", "ai_advanced"]
-  },
-  "usage": {
-    "editors": 4,
-    "workspaces": 2
-  }
+  "plan_id": "team",
+  "plan_name": "Team",
+  "status": "active",
+  "max_workspaces": 3,
+  "current_workspaces": 2,
+  "max_editors": 15,
+  "current_editors": 4,
+  "max_pages_per_workspace": 150,
+  "features": { "analytics": true, "custom_domains": true, "published_docs": true, "hide_badge": true }
 }
 ```
 
 ## Feature gating
 
-When an organization exceeds its plan limits:
+When an organization hits its plan limits:
 
-- **Editors**: New editor invitations are rejected. Existing editors retain access.
-- **Workspaces**: New workspace creation is rejected. Existing workspaces remain accessible.
-- **Gated features**: API returns `403` with a clear error message indicating the required plan.
-
-## Super admin controls
-
-Super admins can manage billing across all organizations:
-
-```
-GET  /api/admin/billing/overview        — Platform-wide billing summary
-GET  /api/admin/billing/subscriptions   — All active subscriptions
-GET  /api/admin/billing/events          — Webhook event log
-PUT  /api/admin/orgs/:id/plan           — Change organization plan
-POST /api/admin/orgs/:id/subscription/override — Override subscription (e.g., comp plans)
-```
+- **Editor seats**: New editor/admin invitations are rejected with `403 PLAN_LIMIT_REACHED`. Existing editors retain access; Commenter/Viewer invitations still work.
+- **Workspaces / pages**: New creation is rejected with the same error code. Existing content remains accessible.
+- **Gated features** (e.g., analytics on Free): API returns `403` indicating the required plan.
 
 ## Subscription lifecycle
 
 ```
 Trial (14 days)
     │
-    ├── User upgrades → Active subscription
+    ├── User subscribes → Active subscription
     │
     └── Trial expires → Grace period (7 days)
                             │
-                            ├── User upgrades → Active subscription
+                            ├── User subscribes → Active subscription
                             │
-                            └── Grace expires → Restricted (Community limits)
+                            └── Grace expires → Restricted
 ```
 
-During the grace period, all features remain available but a banner prompts the user to subscribe. After grace expires, the organization reverts to Community Edition limits.
+During the grace period, everything keeps working while the customer is prompted to subscribe. In the **restricted** state, creating new workspaces, pages, or editor invitations is blocked until billing resumes (a **paused** subscription blocks writes only). Existing content remains readable throughout.

--- a/guides/collaboration.md
+++ b/guides/collaboration.md
@@ -63,32 +63,15 @@ Super Admin
 | **Commenter** | Workspace | View + leave comments on pages |
 | **Editor** | Workspace | View + comment + create, edit, delete pages |
 | **Admin** | Workspace | Full workspace management (settings, git, theme, members) |
-| **Super Admin** | Platform | Full access to all workspaces + platform settings |
+| **Super Admin** | Organization | Full access to all workspaces in the org + org settings and billing |
 
-### Default role for new members
+### Role at invitation
 
-Configure the default role assigned when users accept an invitation:
-
-```yaml
-# .docplatform/config.yaml
-permissions:
-  default_role: viewer
-```
+The role is chosen by the inviter at invitation time — there is no separate "default role" setting. To change someone's role later, use **Settings → Members**.
 
 ### Page-level access
 
-Restrict individual pages to specific roles using frontmatter access rules:
-
-```yaml
----
-title: Internal Runbook
-access:
-  read: ["sre-team", "admin"]
-  write: ["sre-team"]
----
-```
-
-Pages with `access` rules are invisible to users without the required role — they won't appear in search results, navigation, or published docs. Access rules can only **restrict** within a user's role, never grant beyond it.
+Frontmatter `access` rules are parsed and preserved but **not enforced** — access control is role-based at the workspace level. See [Roles & Permissions](../configuration/permissions.md).
 
 ## Real-time presence
 
@@ -103,11 +86,10 @@ Presence is powered by WebSocket connections and updates in real time.
 
 | Parameter | Value |
 |---|---|
-| **Protocol** | WebSocket (authenticated via one-time ticket) |
+| **Protocol** | WebSocket (authenticated via the `dp_ws_token` HttpOnly cookie) |
 | **Heartbeat interval** | Every 30 seconds |
 | **Eviction timeout** | 90 seconds without heartbeat |
-| **Events** | `presence-join` (first connect), `presence-leave` (timeout or disconnect) |
-| **Buffer** | 256 events (global broadcast buffer, prevents backpressure) |
+| **Events** | `presence-join`, `presence-update`, `presence-leave` |
 
 The WebSocket connection also delivers real-time content events:
 
@@ -135,52 +117,39 @@ To avoid conflicts:
 - Presence indicators help your team coordinate who's editing what
 - For high-concurrency teams, consider shorter git sync intervals
 
-## Audit trail
+## Activity feed
 
-Every content mutation is logged with:
+Every workspace has an activity feed recording who did what, when.
 
-| Field | Description |
-|---|---|
-| **Timestamp** | When the action occurred (UTC) |
-| **User** | Who performed the action (email, user ID) |
-| **Operation** | What happened: `create`, `update`, `delete`, `publish`, `unpublish` |
-| **Page** | Which page was affected (ID, title, path) |
-| **Source** | Where the change came from: `web_editor`, `git_sync`, `api` |
-| **Content hash** | SHA-256 of the new content (for verification) |
+### Viewing activity
 
-### Viewing the audit log
+Open **Workspace Settings** → **Activity**, or use the API:
 
-Access the audit log from **Workspace Settings** → **Activity**.
+```bash
+curl "http://localhost:3000/api/v1/workspaces/{id}/activity?limit=50&action=page_created" \
+  -H "Authorization: Bearer {token}"
+```
 
-Filter by:
+Per-page history is available at `GET /api/v1/workspaces/{id}/page-activity?page={path}`.
 
-- **User** — see all changes by a specific team member
-- **Page** — see the full history of a specific page
-- **Date range** — narrow to a time window
-- **Operation type** — filter to creates, updates, deletes, etc.
+### Activity action types
 
-### Audit action types
-
-The `action` field in the audit log uses dot-notation for precise filtering:
+Filter the feed with the `action` query parameter:
 
 | Action | Description |
 |---|---|
-| `page.create` | New page created |
-| `page.update` | Page content or frontmatter modified |
-| `page.delete` | Page deleted |
-| `page.publish` | Page published (made public) |
-| `page.unpublish` | Page unpublished |
-| `auth.login` | User signed in |
-| `auth.register` | New user registered |
-| `auth.password_reset` | Password reset completed |
-| `workspace.create` | New workspace created |
-| `workspace.member_add` | User added to workspace |
-| `workspace.member_remove` | User removed from workspace |
-| `workspace.role_change` | User's role changed |
+| `page_created` | New page created |
+| `page_updated` | Page content or frontmatter modified |
+| `page_deleted` | Page deleted |
+| `comment_added` | Comment posted on a page |
+| `comment_resolved` | Comment thread resolved |
+| `member_joined` | User joined the workspace |
+| `member_left` | User left or was removed |
+| `sync_completed` | Git sync finished |
 
 ### Retention
 
-Audit logs are stored in SQLite alongside your regular data. They're included in daily backups. Audit logs are retained indefinitely.
+Activity records are stored in SQLite alongside your regular data and included in daily backups.
 
 ## Email notifications
 
@@ -208,7 +177,7 @@ Without SMTP, invitation links and password reset tokens are printed to stdout (
 ## Tips for team workflows
 
 - **One writer per page** — use presence indicators to avoid conflicts
-- **Editors write, Admins publish** — separate concerns with roles
+- **Editors write, reviewers publish** — drafts stay off the published site until someone sets `publish: true`
 - **Use tags for ownership** — tag pages with `owner:jane` to clarify responsibility
 - **Git for review workflows** — push changes to a branch, open a PR, merge after review
-- **Audit before publish** — review the audit log for unexpected changes before making content public
+- **Review before publish** — check the activity feed for unexpected changes before making content public

--- a/guides/editor.md
+++ b/guides/editor.md
@@ -43,8 +43,7 @@ The collapsible frontmatter section at the top of the editor provides form field
 | **Title** | Page heading and navigation label | Yes |
 | **Description** | Summary shown in search results and SEO meta tags | No |
 | **Tags** | Categorization labels for filtering and discovery | No |
-| **Published** | Toggle to include/exclude from the public site | No |
-| **Access** | Per-operation access rules (read/write/admin by role) | No |
+| **Publish** | Toggle to include/exclude from the public site | No |
 
 Changes to frontmatter fields update the YAML block in the `.md` file automatically.
 
@@ -57,13 +56,12 @@ The formatting toolbar provides quick access to:
 | **Bold** | `Cmd+B` | Bold text |
 | **Italic** | `Cmd+I` | Italic text |
 | **Code** | `Cmd+E` | Inline code |
-| **Link** | `Cmd+K` | Insert or edit hyperlink |
-| **Heading 1-3** | `Cmd+Shift+1/2/3` | Section headings |
+| **Link** | — | Insert or edit hyperlink |
+| **Heading 1-3** | `Cmd+Alt+1/2/3` | Section headings |
 | **Bullet list** | `Cmd+Shift+8` | Unordered list |
 | **Ordered list** | `Cmd+Shift+7` | Numbered list |
-| **Task list** | `Cmd+Shift+9` | Checkbox list |
-| **Blockquote** | `Cmd+Shift+>` | Block quote |
-| **Code block** | `Cmd+Alt+C` | Fenced code block with language selector |
+| **Blockquote** | `Cmd+Shift+B` | Block quote |
+| **Code block** | `Cmd+Alt+C` | Fenced code block |
 | **Image** | — | Upload or paste an image |
 | **Table** | — | Insert a table |
 | **Horizontal rule** | `---` | Divider line |
@@ -97,7 +95,7 @@ DocPlatform autosaves your work every few seconds. You'll see a status indicator
 | **Saving...** | Write in progress |
 | **Unsaved changes** | Edits pending save (poor connection or error) |
 
-If git sync is enabled, each save triggers an auto-commit. Commits are batched — rapid edits produce a single commit with the message format: `docs: update {page-title}`.
+If git sync is enabled (auto-commit on, remote configured), each save triggers an auto-commit authored as you, with a message like `Update {page-path} via web editor` (`Create` / `Delete` / `Move` for those operations).
 
 ## Working with content
 
@@ -118,7 +116,7 @@ Insert tables from the toolbar. Tables support:
 
 ### Code blocks
 
-Insert code blocks with the toolbar or by typing triple backticks (`` ``` ``). Select a language for syntax highlighting — Chroma supports 200+ languages.
+Insert code blocks with the toolbar or by typing triple backticks (`` ``` ``). Set the language by typing it after the opening fence (e.g., ```` ```javascript ````) or in raw Markdown mode — published pages render syntax highlighting for 200+ languages.
 
 ```javascript
 // Code blocks with syntax highlighting
@@ -145,10 +143,8 @@ DocPlatform validates internal links and the `doctor` command reports broken ref
 | `Cmd+K` | Open search dialog |
 | `Cmd+Z` | Undo |
 | `Cmd+Shift+Z` | Redo |
-| `Cmd+/` | Toggle Markdown comment |
 | `Tab` | Indent list item |
 | `Shift+Tab` | Outdent list item |
-| `Cmd+Enter` | Toggle task completion (in task lists) |
 | `Escape` | Close dialogs / deselect |
 
 > **Note:** On Windows and Linux, replace `Cmd` with `Ctrl`.
@@ -162,6 +158,5 @@ DocPlatform does not support simultaneous editing of the same page by multiple u
 ## Tips
 
 - **Drag pages** in the sidebar to reorganize your documentation structure
-- **Slash commands** — type `/` in the editor to quickly insert components (callout, code block, table, etc.)
 - **Paste rich text** from Google Docs, Notion, or Confluence — the editor converts it to clean Markdown
-- **Frontmatter defaults** — set workspace-level defaults for `published`, `access`, and `tags` to reduce repetitive entry
+- **Use raw Markdown mode** for custom components (Callout, Tabs, etc.) and precise frontmatter edits

--- a/guides/git-integration.md
+++ b/guides/git-integration.md
@@ -34,7 +34,7 @@ DocPlatform's bidirectional git sync lets your team work however they prefer. Te
 
 1. You save a page in the web editor
 2. Content Ledger writes the `.md` file to disk
-3. Git engine auto-commits: `docs: update {page-title}`
+3. Git engine auto-commits as you: `Update {page-path} via web editor`
 4. Commits are pushed to the remote repository
 
 ### Git → Web (inbound)
@@ -78,7 +78,7 @@ The three-tier matching ensures that:
 
 ### What happens when the workspace directory is missing
 
-If the workspace `docs/` directory is missing or empty when a sync runs (e.g., due to a failed clone, a misconfigured path, or a filesystem error), the reconciler **refuses to delete** any pages and returns an error instead of proceeding. Without this safety check, the reconciler would see zero files on disk and soft-delete every page in the database — a catastrophic outcome for a corrupted or misconfigured workspace. The sync logs the error as `reconcile: workspace directory missing or empty, aborting` and the workspace enters a `sync_error` state visible in the admin dashboard.
+If the workspace `docs/` directory is missing or empty when a sync runs (e.g., due to a failed clone, a misconfigured path, or a filesystem error), the reconciler **refuses to delete** any pages and returns an error instead of proceeding. Without this safety check, the reconciler would see zero files on disk and soft-delete every page in the database — a catastrophic outcome for a corrupted or misconfigured workspace. The sync logs the error as `reconcile: workspace directory missing or empty, aborting` and the workspace's sync status reports the error.
 
 ## Setup
 
@@ -94,10 +94,10 @@ docplatform init \
   --branch main
 ```
 
-**After initialization** — edit the workspace settings. Git configuration is stored in the workspace database record and can be updated via the web UI (**Settings** → **Git**) or the API:
+**After creation** — connect from the web UI (**Settings** → **Git**): validate a GitHub personal access token, pick the repository and branch. The token is encrypted at rest (AES-256-GCM; requires `GIT_ENCRYPTION_KEY`). Git settings are stored in the workspace database record and can also be updated via the API:
 
 ```bash
-curl -X PUT http://localhost:3000/api/v1/workspaces/{id}/settings \
+curl -X PATCH http://localhost:3000/api/v1/workspaces/{id} \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -108,7 +108,9 @@ curl -X PUT http://localhost:3000/api/v1/workspaces/{id}/settings \
   }'
 ```
 
-Restart the server or trigger a manual sync.
+No restart is required — changes take effect on the next sync cycle.
+
+> **Provider support:** the guided web-UI connection flow supports **GitHub personal access tokens**. GitLab and Bitbucket appear in the provider list but their connection flows are not yet implemented — for those, configure a raw `git_remote` URL (SSH or HTTPS with token) instead.
 
 ### Authentication
 
@@ -142,15 +144,15 @@ Or use a Git credential helper configured on the host.
 
 ### Auto-commit
 
-When `git_auto_commit: true` (default), every save in the web editor produces a git commit. Rapid edits within a short window are batched into a single commit.
+When `git_auto_commit: true` (default) and a git remote is configured, every save in the web editor produces a git commit.
 
 Commit message format:
 
 ```
-docs: update Getting Started
+Update guides/getting-started.md via web editor
 ```
 
-Author: `DocPlatform <docplatform@local>`
+(`Create` / `Delete` / `Move` for those operations.) The commit **author is the acting user** — their name and email from their DocPlatform account — so `git blame` reflects who actually made each change. Automatic conflict-merge commits are authored as `sync@valoryx.dev`.
 
 Set `git_auto_commit: false` to disable auto-commit. In this mode, the web editor writes to the filesystem but does not create git commits — useful if you want to commit manually or on a schedule.
 
@@ -166,30 +168,31 @@ Lower intervals mean faster sync but more network traffic.
 
 ### Webhooks
 
-For instant sync, configure a webhook in your repository:
+For instant sync, configure a webhook in your repository.
 
-DocPlatform uses a single webhook endpoint that auto-detects the provider (GitHub, GitLab, Bitbucket) from the payload format.
+DocPlatform generates a **per-workspace webhook secret** automatically (find it in **Settings** → **Git**). The single endpoint accepts GitHub (`X-Hub-Signature-256`), GitLab (`X-Gitlab-Token`), and Bitbucket (`X-Hub-Signature`) signature schemes. Pushes to branches other than the workspace's configured branch are ignored.
 
 **GitHub:**
 
 1. Go to **Settings** → **Webhooks** → **Add webhook**
 2. Payload URL: `https://your-domain.com/api/git/webhook/{workspace-id}`
 3. Content type: `application/json`
-4. Secret: Set `GIT_WEBHOOK_SECRET` environment variable to match
+4. Secret: paste the workspace's webhook secret
 5. Events: Select **Push events**
 
 **GitLab:**
 
 1. Go to **Settings** → **Webhooks**
 2. URL: `https://your-domain.com/api/git/webhook/{workspace-id}`
-3. Secret token: Match `GIT_WEBHOOK_SECRET`
+3. Secret token: paste the workspace's webhook secret
 4. Trigger: **Push events**
 
 **Bitbucket:**
 
 1. Go to **Repository settings** → **Webhooks** → **Add webhook**
 2. URL: `https://your-domain.com/api/git/webhook/{workspace-id}`
-3. Triggers: **Repository push**
+3. Secret: paste the workspace's webhook secret
+4. Triggers: **Repository push**
 
 ### Manual sync
 
@@ -217,7 +220,8 @@ DocPlatform tracks content hashes (SHA-256) for every page. When pulling remote 
    - **Theirs** — the remote version (git push)
    - **Base** — the common ancestor before divergence
 4. The user resolves by choosing or merging content from the three versions
-5. A conflict branch (`conflict/{page-slug}-{timestamp}`) is created with the local version
+
+For the workspace manifests `redirects.yaml`, `workspace.yaml`, and `publish.yaml` (under `.docplatform/`), DocPlatform attempts an automatic three-way merge first. Markdown pages and `nav.yaml` are **never** auto-merged — they always go to a human.
 
 ### Preventing conflicts
 
@@ -231,10 +235,8 @@ DocPlatform tracks content hashes (SHA-256) for every page. When pulling remote 
 Whenever a remote push contains multiple changed files, DocPlatform uses batch mode:
 
 1. Fetches all changed files in a single diff
-2. Acquires per-path mutexes for all affected paths (sorted to prevent deadlock)
-3. Processes all files in a single database transaction
-4. Invalidates the permission cache once (not per-file)
-5. Emits a `bulk-sync` WebSocket event with the total changed count
+2. Processes the changes as one reconciliation pass
+3. Emits a `bulk-sync` WebSocket event with the total changed count
 
 This prevents notification storms and database overhead when large changes are pushed (e.g., initial repository import or bulk restructuring).
 
@@ -255,34 +257,18 @@ Conflicts persist until explicitly resolved via the web UI or API. The `docplatf
 
 ## Git engine details
 
-DocPlatform uses a hybrid git engine that selects the best backend automatically:
-
-| Operation | Engine | Notes |
-|---|---|---|
-| Clone / Pull / Push | **Native git CLI** (subprocess) | Always uses native git for network operations |
-| Stage / Commit / Log / HEAD | **go-git** (in-process) | Pure Go, no subprocess overhead |
-| Status / Diff | **go-git** under 5K files, **Native git CLI** over 5K files | Switches at 5,000 files for performance |
-
-A worker pool of **4 concurrent workers** handles git operations across all workspaces. Each workspace has its own mutex — operations on different workspaces run in parallel, while operations on the same workspace are serialized.
-
-Auto-commit messages use this format:
-
-```
-docs: update {page-title}
-```
-
-Author: `DocPlatform <docplatform@local>`
+DocPlatform uses a **hybrid git engine** that routes each operation to the best backend automatically: a pure-Go engine (go-git) for everyday operations, switching to the native `git` CLI for large repositories (file-count and memory thresholds). Operations on the same workspace are serialized; different workspaces sync in parallel.
 
 ## Working with existing repositories
 
 DocPlatform works with existing documentation repositories. When you connect a repo:
 
 1. The repo is cloned (or pulled if it already exists locally)
-2. All `.md` files in the `docs/` directory are indexed
+2. All `.md` files in the repository are indexed
 3. Frontmatter is parsed and page metadata is stored in SQLite
 4. The search index is built incrementally
 
-Files outside `docs/` are not indexed or displayed in the editor, but they remain in the git repository untouched.
+Non-Markdown files are not indexed or displayed in the editor, but they remain in the git repository untouched.
 
 ### Importing from other platforms
 
@@ -290,18 +276,18 @@ DocPlatform works with any Markdown content. Here's how to migrate from common p
 
 | Source | Export method | Notes |
 |---|---|---|
-| **Docusaurus** | Direct copy | Already `.md`-based — copy `docs/` directory as-is, add frontmatter if missing |
+| **Docusaurus** | Direct copy | Already `.md`-based — copy your docs directory as-is, add frontmatter if missing |
 | **GitBook** | JSON export → convert | Export via GitBook API, convert to Markdown |
-| **Notion** | Markdown export | Export workspace as Markdown, restructure into `docs/` hierarchy |
+| **Notion** | Markdown export | Export workspace as Markdown, restructure into a folder hierarchy |
 | **Confluence** | HTML export → convert | Export spaces as HTML, convert to Markdown with pandoc or similar |
 | **Wiki.js** | Database export | Export pages as Markdown from the admin panel |
 
 **General migration steps:**
 
 1. Export your content as Markdown files
-2. Place them in a git repository under `docs/`
+2. Place them in a git repository
 3. Add YAML frontmatter (at minimum, `title`) to each file
 4. Connect the repository to DocPlatform
-5. Run `docplatform rebuild` to force a full reconciliation
+5. Run `docplatform rebuild --workspace {id}` to force a full reconciliation
 
 DocPlatform's reconciler automatically discovers all `.md` files, parses their frontmatter, assigns ULIDs to pages missing an `id` field, and builds the search index.

--- a/guides/markdown.md
+++ b/guides/markdown.md
@@ -104,24 +104,23 @@ DocPlatform validates internal links. The `doctor` command reports any broken re
 
 ### Wikilinks
 
-DocPlatform supports **wikilinks** for linking between pages without specifying full paths. Wikilinks use double-bracket syntax:
+DocPlatform supports **wikilinks** with double-bracket syntax. The link target is the page's path (without the `.md` extension):
 
 ```markdown
-See [[Getting Started]] for setup instructions.
-Check [[API Authentication|the auth guide]] for token details.
-Link by page ID for rename-proof references: [[01HJK...]]
+See [[getting-started/index]] for setup instructions.
+Check [[api/authentication|the auth guide]] for token details.
+Jump to a section: [[api/authentication#tokens]]
 ```
 
 | Syntax | Description |
 |---|---|
-| `[[Page Title]]` | Link by page title (auto-resolved to path) |
-| `[[Page Title\|display text]]` | Link with custom display text |
-| `[[01HJK...]]` | Link by stable page ID (survives renames) |
+| `[[page/path]]` | Link by page path |
+| `[[page/path\|display text]]` | Link with custom display text |
+| `[[page/path#heading]]` | Link to a specific heading |
 
 **Wikilink features:**
-- **Hover preview** — hovering a wikilink shows a preview popup with the target page's title and description
 - **Auto-repair on rename** — when a page is renamed or moved, all wikilinks pointing to it are automatically updated across the workspace
-- **Broken link detection** — `docplatform doctor` reports wikilinks that point to nonexistent pages
+- **Broken link detection** — `docplatform doctor` and the `docplatform_validate_links` MCP tool report wikilinks that point to nonexistent pages
 
 ## Frontmatter
 
@@ -132,10 +131,9 @@ Every page starts with a YAML frontmatter block delimited by `---`:
 title: Page Title
 description: A brief summary for search results and SEO.
 tags: [guide, getting-started]
-published: true
-access:
-  read: ["engineering", "product"]
-  write: ["engineering"]
+publish: true
+status: draft
+nav_order: 2
 ---
 ```
 
@@ -144,17 +142,14 @@ access:
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `title` | string | Yes | — | Page title shown in navigation and headings |
-| `id` | string | No | Auto-generated ULID | Stable page identifier (survives renames, enables ID-based wikilinks) |
+| `id` | string | No | Auto-generated ULID | Stable page identifier that survives renames and database rebuilds |
 | `description` | string | No | — | Summary for search results, SEO meta tags |
-| `tags` | string[] | No | `[]` | Categories for filtering and search |
-| `published` | boolean | No | `false` | Include in the published documentation site |
+| `tags` | string[] or string | No | `[]` | Categories for filtering and search — accepts a YAML list or a comma-separated string |
+| `publish` | boolean | No | `false` | Include in the published documentation site (the `.docplatform/publish.yaml` overlay can override this per path) |
 | `status` | string | No | `draft` | Page lifecycle: `draft`, `published`, `archived` |
-| `access` | object | No | — | Per-operation access rules (see [Permissions](../configuration/permissions.md)) |
-| `access.read` | string[] | No | — | Roles that can view this page |
-| `access.write` | string[] | No | — | Roles that can edit this page |
-| `access.admin` | string[] | No | — | Roles/user IDs (`@01HJK...`) that can manage this page |
-
-The `id` field is auto-generated as a ULID when a page is created. On git import, if the `id` is missing, DocPlatform generates one and writes it back on the next sync. This ID enables rename-proof wikilinks and survives database rebuilds.
+| `nav_order` | int | No | — | Ordering hint for sidebar navigation |
+| `seo` | map | No | — | Per-page SEO overrides |
+| `access` | object | No | — | Parsed and preserved, but **not enforced** — see [Permissions](../configuration/permissions.md) |
 
 ## Custom components
 
@@ -203,16 +198,13 @@ Standard fenced code blocks are automatically enhanced with:
 
 - **Syntax highlighting** — 200+ languages via Chroma
 - **Copy button** — one-click copy to clipboard
-- **Language label** — displayed in the top-right corner
-- **Line numbers** — optional, enabled with `showLineNumbers`
 
 ````markdown
-```typescript {showLineNumbers}
+```typescript
 interface Page {
   id: string;
   title: string;
   content: string;
-  published: boolean;
 }
 ```
 ````
@@ -289,14 +281,11 @@ Numbered step-by-step instructions with visual progress indicators.
 ::step[Download]
 Get the latest binary from GitHub Releases.
 ::
-::step[Initialize]
-Run `docplatform init` to create your workspace.
-::
 ::step[Start the server]
 Run `docplatform serve` and open http://localhost:3000.
 ::
 ::step[Register]
-Create your admin account — the first user becomes Super Admin.
+Create your account — registering creates your organization and starter workspace.
 ::
 :::
 ```
@@ -355,60 +344,65 @@ Display directory structures with syntax highlighting.
 
 ### Mermaid diagrams
 
-Render diagrams from text using Mermaid syntax.
+Render diagrams from text using Mermaid syntax inside the `mermaid` directive:
 
-````markdown
-```mermaid
+```markdown
+:::mermaid
 graph TD
     A[Web Editor] --> B[Content Ledger]
     C[Git Push] --> B
     B --> D[Filesystem]
     B --> E[Database]
     B --> F[Search Index]
+:::
 ```
-````
 
-Supports flowcharts, sequence diagrams, class diagrams, state diagrams, and more.
+Supports flowcharts, sequence diagrams, class diagrams, state diagrams, and more. Diagrams render client-side on published pages.
 
 ### KaTeX math
 
-Render mathematical notation using LaTeX syntax.
+Render mathematical notation using LaTeX syntax inside the `katex` directive:
 
 ```markdown
-Inline math: $E = mc^2$
-
-Block math:
-$$
+:::katex
 \int_{0}^{\infty} e^{-x^2} dx = \frac{\sqrt{\pi}}{2}
-$$
+:::
 ```
+
+### Badge
+
+Inline status labels: `:::badge[variant]` with the label text as content.
+
+### Table of contents
+
+`:::toc` renders a table of contents generated from the page's headings.
+
+### Embed
+
+`:::embed` embeds external content by URL.
 
 ## Component usage in the editor
 
 ### Rich text mode
 
-In the rich editor, components render as interactive blocks. Insert them using:
-
-- **Slash commands** — type `/` then the component name (e.g., `/callout`, `/tabs`)
-- **Toolbar** — click the **+** button → select a component
-- **Keyboard** — no dedicated shortcuts (use slash commands)
+In the rich editor, insert components from the toolbar (**+** button → select a component).
 
 ### Raw Markdown mode
 
-In raw mode, write the directive syntax directly. The editor provides syntax highlighting for component blocks.
+In raw mode, write the directive syntax directly.
 
 ## Markdown extensions
 
-Beyond CommonMark, DocPlatform supports:
+Beyond CommonMark, DocPlatform supports the GitHub Flavored Markdown (GFM) extension set plus DocPlatform-specific additions:
 
 | Extension | Syntax | Description |
 |---|---|---|
-| **Wikilinks** | `[[Page Title]]` | Cross-page linking with hover preview and auto-repair |
-| **Task lists** | `- [ ] item` | Interactive checkboxes |
-| **Strikethrough** | `~~text~~` | Struck-through text |
+| **Wikilinks** | `[[page/path]]` | Cross-page linking with auto-repair on rename |
+| **Task lists** | `- [ ] item` | Checkboxes (GFM) |
+| **Strikethrough** | `~~text~~` | Struck-through text (GFM) |
 | **Tables** | GFM tables | With alignment support |
-| **Autolinks** | `https://...` | URLs auto-linked |
-| **Footnotes** | `[^1]` | Reference-style footnotes |
+| **Autolinks** | `https://...` | URLs auto-linked (GFM) |
 | **Heading anchors** | Auto-generated | Deep linking to sections |
-| **Mermaid** | ` ```mermaid ` | Inline diagrams from text |
-| **KaTeX** | `$...$` / `$$...$$` | Mathematical notation |
+| **Directives** | `:::component` | 15 built-in components (above) |
+
+Footnote syntax (`[^1]`) is not supported.

--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -92,9 +92,9 @@ Then configure your MCP client to connect via Streamable HTTP at `http://your-se
 
 ---
 
-## Available tools (24)
+## Available tools (26)
 
-The MCP server exposes 24 tools across 9 categories.
+The MCP server exposes 26 tools across 10 categories.
 
 ### Content (6 tools)
 
@@ -144,12 +144,13 @@ The `get_manifest` tool gives AI agents a complete overview of the workspace str
 | `docplatform_get_theme` | Get the current published site theme | — |
 | `docplatform_update_theme` | Update the published site theme | `theme` (default, dark, forest, rose, amber, minimal, corporate) |
 
-### Management (2 tools)
+### Management (3 tools)
 
 | Tool | Description | Key parameters |
 |---|---|---|
 | `docplatform_create_workspace` | Create a new documentation workspace. The authenticated user becomes workspace admin | `name`, `slug`, `description` |
 | `docplatform_get_workspace` | Get workspace details including your role, member count, page count, git sync status, and publish settings | `workspace_id` |
+| `docplatform_publish_workspace` | Enable or disable the workspace's published site (same effect as the REST publish toggle) | `workspace_id`, `published` |
 
 ### Versioning (2 tools)
 
@@ -185,6 +186,14 @@ Requires an AI provider configured on the server (Anthropic or OpenAI).
 | `docplatform_list_comments` | List threaded comments on a page with author, body, anchors, and resolution status | `page`, `limit` |
 | `docplatform_add_comment` | Add a comment to a page. Supports @mentions and threaded replies | `page`, `body`, `parent_id` |
 
+### Sync (1 tool, conditional)
+
+| Tool | Description | Key parameters |
+|---|---|---|
+| `docplatform_resolve_sync_conflict` | Resolve a pending git-sync conflict — keep the local version, the remote version, or supply explicit content per path; commits and pushes with your identity | `conflict_id`, `resolution` (`kept_local`, `kept_remote`, `custom`) |
+
+This tool is only registered when the MCP server is started with a configured server URL (`DOCPLATFORM_SERVER_URL`) — it proxies to the REST conflict-resolution endpoint and requires the Editor role. Triggering a sync itself is REST-only (`POST /api/v1/workspaces/:id/sync`); there is no `trigger_sync` MCP tool.
+
 ---
 
 ## Authentication
@@ -196,8 +205,10 @@ API keys support three scopes:
 | Scope | Allows |
 |---|---|
 | `read` | list_pages, read_page, search, get_context, get_tree, get_manifest, list_workspaces, get_workspace, list_versions, get_theme, validate_links, quality_scan, export, get_activity, list_comments |
-| `write` | write_page, update_page, move_page, create_workspace, create_version, update_theme, writing_assist, add_comment |
+| `write` | write_page, update_page, move_page, create_workspace, create_version, update_theme, writing_assist, add_comment, publish_workspace, resolve_sync_conflict |
 | `delete` | delete_page |
+
+In addition to scopes, every tool call is checked against your **workspace role** — a `write`-scoped key held by a Viewer still can't write.
 
 By default, new API keys have all three scopes. You can restrict scope when creating the key.
 

--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -200,7 +200,7 @@ This tool is only registered when the MCP server is started with a configured se
 
 ### API key scopes
 
-API keys support three scopes:
+API keys support five scopes — `read`, `write`, `delete`, `admin`, and `admin:read` (see [Authentication](../configuration/authentication.md#scopes) for the full model). The three content scopes map to MCP tools as follows:
 
 | Scope | Allows |
 |---|---|
@@ -210,7 +210,7 @@ API keys support three scopes:
 
 In addition to scopes, every tool call is checked against your **workspace role** — a `write`-scoped key held by a Viewer still can't write.
 
-By default, new API keys have all three scopes. You can restrict scope when creating the key.
+By default, new API keys have all three content scopes (`read`, `write`, `delete`). You can restrict scope when creating the key.
 
 ### Key format
 

--- a/guides/publishing.md
+++ b/guides/publishing.md
@@ -19,7 +19,7 @@ http://localhost:3000/p/my-docs/api/auth      → api/auth.md
 
 Pages are rendered from Markdown to HTML on request using goldmark (CommonMark-compliant) with Chroma syntax highlighting (Dracula theme) for code blocks.
 
-> **Slug limitation:** sites whose slug contains a `/` cannot be reached through the `/p/` path — they are only reachable through a custom domain. Keep slugs to a single path segment if you rely on `/p/` URLs.
+> **Slug limitation:** site slugs must be a **single path segment**. A slug containing `/` breaks routing both on `/p/` URLs and on custom domains (custom-domain requests are internally rewritten to `/p/{slug}/...`). Use a slug like `my-docs`, not `team/my-docs`.
 
 ### What appears on the published site
 

--- a/guides/publishing.md
+++ b/guides/publishing.md
@@ -9,64 +9,47 @@ DocPlatform can serve your documentation as a website — complete with a naviga
 
 ## How publishing works
 
-Published docs are served at `/p/{workspace-slug}/{page-path}`:
+Published docs are served at `/p/{site-slug}/{page-path}`:
 
 ```
-http://localhost:3000/p/my-docs/              → docs/index.md
-http://localhost:3000/p/my-docs/quickstart    → docs/quickstart.md
-http://localhost:3000/p/my-docs/api/auth      → docs/api/auth.md
+http://localhost:3000/p/my-docs/              → index.md
+http://localhost:3000/p/my-docs/quickstart    → quickstart.md
+http://localhost:3000/p/my-docs/api/auth      → api/auth.md
 ```
 
 Pages are rendered from Markdown to HTML on request using goldmark (CommonMark-compliant) with Chroma syntax highlighting (Dracula theme) for code blocks.
 
-### Page status lifecycle
+> **Slug limitation:** sites whose slug contains a `/` cannot be reached through the `/p/` path — they are only reachable through a custom domain. Keep slugs to a single path segment if you rely on `/p/` URLs.
 
-Pages have a `status` field that controls their visibility:
+### What appears on the published site
 
-| Status | In editor | In published site | In search |
-|---|---|---|---|
-| `draft` (default) | Visible | Hidden | Visible to members only |
-| `published` | Visible | Visible | Visible per access rules |
-| `archived` | Visible (dimmed) | Hidden | Hidden |
+Whether a page appears on the published site is a three-source decision, evaluated in this order (later sources win):
 
-Set the status in frontmatter:
+1. Frontmatter `publish:` flag on the page
+2. The `pages.publish` column in the database (kept in sync with frontmatter)
+3. The `.docplatform/publish.yaml` overlay — an entry for the page's path **overrides** frontmatter
 
-```yaml
----
-title: My Page
-status: published    # draft, published, or archived
-publish: true        # shorthand — equivalent to status: published
----
-```
-
-The `publish: true` shorthand and `status: published` are equivalent. Use whichever you prefer.
+Unpublished pages return 404 on the published site — for everyone, including workspace members. The separate frontmatter `status:` field (`draft` / `published` / `archived`) is editorial metadata and does **not** control published-site visibility — only `publish:` does.
 
 ## Enable publishing
 
 ### Per-page
 
-Set `published: true` in the page's frontmatter:
+Set `publish: true` in the page's frontmatter:
 
 ```yaml
 ---
 title: API Authentication
 description: How to authenticate with the API.
-published: true
+publish: true
 ---
 ```
 
-Or toggle the **Published** switch in the frontmatter form of the web editor.
+Or toggle the **Publish** switch in the frontmatter form of the web editor.
 
-### Workspace-level default
+### Bulk control with the publish overlay
 
-Set a workspace-level default so new pages are published automatically:
-
-```yaml
-# .docplatform/config.yaml
-publishing:
-  default_published: true
-  require_explicit_unpublish: false
-```
+To manage publish decisions as code (visible in code review), use the `.docplatform/publish.yaml` overlay — see [Workspace Settings](../configuration/workspace-config.md#publishyaml).
 
 ## Themes
 
@@ -82,36 +65,35 @@ DocPlatform ships with 7 built-in themes for published documentation:
 | **Minimal** | Stripped-down, typography-focused |
 | **Corporate** | Professional blue/gray palette |
 
-Set the theme in your workspace config:
+Set the theme in **Workspace Settings → Publishing** (`PUT /api/v1/workspaces/:id/admin/settings` with `{"theme": "dark"}`), or in `.docplatform/workspace.yaml`:
 
 ```yaml
-# .docplatform/config.yaml
-theme:
-  mode: auto    # light, dark, or auto (follows system preference)
-  accent: blue  # or use a named theme
+# .docplatform/workspace.yaml
+theme: dark
 ```
 
-Each theme supports automatic light/dark mode switching based on the visitor's system preference when `mode: auto` is set.
+Invalid theme names fall back to `default`.
 
 ## Published site features
 
 ### Navigation
 
-The published site generates a sidebar navigation from your page hierarchy. The order matches the sidebar in the web editor.
+The published site generates a sidebar navigation from your page hierarchy by default.
 
-To customize navigation order, adjust the `navigation` section in your workspace config:
+To customize it, either arrange navigation groups in **Workspace Settings → Publishing → Navigation** (`PUT /api/v1/workspaces/:id/admin/navigation`), or maintain a `.docplatform/nav.yaml` file in the workspace:
 
 ```yaml
-# .docplatform/config.yaml
-navigation:
-  - title: "Getting Started"
-    path: "getting-started/index.md"
+# .docplatform/nav.yaml
+version: 1
+tree:
+  - file: index.md
+  - section: "Getting Started"
     children:
-      - title: "Installation"
-        path: "getting-started/installation.md"
-      - title: "Quickstart"
-        path: "getting-started/quickstart.md"
+      - file: getting-started/installation.md
+      - file: getting-started/quickstart.md
 ```
+
+See [Workspace Settings](../configuration/workspace-config.md#navyaml) for all node types. Use the frontmatter `nav_order` field for simple ordering hints without a full nav file.
 
 ### Syntax highlighting
 
@@ -140,6 +122,18 @@ DocPlatform generates SEO metadata automatically from your page frontmatter:
 | `sitemap.xml` | Auto-generated at `/p/{slug}/sitemap.xml` |
 | `robots.txt` | Auto-generated at `/p/{slug}/robots.txt` |
 | RSS feed | Auto-generated at `/p/{slug}/rss.xml` |
+
+### AI discoverability
+
+Every published site also exposes endpoints designed for AI agents and LLM ingestion:
+
+| Endpoint | Content |
+|---|---|
+| `/p/{slug}/llms.txt` | Plain-text index of the site's published pages |
+| `/p/{slug}/llms-full.txt` | Full Markdown content of all published pages (capped at 200 pages) |
+| `/p/{slug}/manifest.json` | Machine-readable workspace manifest |
+
+All discovery endpoints respect the site's visibility setting.
 
 ### Access control
 
@@ -299,7 +293,7 @@ export CADDY_ADMIN_URL=http://localhost:2019
 export CADDY_ASK_SECRET=your-shared-secret
 ```
 
-3. **Assign a custom domain** to a workspace via the API or admin UI:
+3. **Assign a custom domain** to a workspace via the API or workspace settings:
 
 ```bash
 curl -X PUT /api/v1/workspaces/{id}/custom-domain \
@@ -309,24 +303,17 @@ curl -X PUT /api/v1/workspaces/{id}/custom-domain \
 
 4. **Point DNS** — Add a CNAME or A record pointing to your DocPlatform server.
 
-DocPlatform verifies DNS automatically and provisions TLS certificates on first request. No manual certificate management required.
+DocPlatform verifies DNS automatically and provisions TLS certificates on first request. No manual certificate management required. If `CADDY_ASK_SECRET` is empty, the ask endpoint rejects all requests (fail-closed) — custom-domain TLS will not provision until it is set.
 
 ### Managing custom domains
+
+Requires the workspace Admin role:
 
 | Operation | Endpoint |
 |---|---|
 | Set domain | `PUT /api/v1/workspaces/:id/custom-domain` |
 | Check status | `GET /api/v1/workspaces/:id/custom-domain` |
 | Remove domain | `DELETE /api/v1/workspaces/:id/custom-domain` |
-
-Super admins can manage all domains from the admin panel:
-
-| Operation | Endpoint |
-|---|---|
-| List all domains | `GET /api/admin/domains` |
-| Verify DNS | `POST /api/admin/domains/:id/verify` |
-| Provision TLS | `POST /api/admin/domains/:id/provision` |
-| Delete domain | `DELETE /api/admin/domains/:id` |
 
 ## Caching
 
@@ -339,9 +326,9 @@ Published pages are cached for performance:
 
 The cache key is based on the page's content hash. When content changes, the ETag changes automatically and cached versions are invalidated.
 
-### Asset URL rewriting
+### Uploaded images
 
-In the web editor, assets use relative paths (`assets/screenshot.png`). In published docs, these are automatically rewritten to absolute paths (`/p/{slug}/assets/screenshot.png`) so images and files load correctly at any URL depth.
+Images uploaded through the editor are served from the workspace's uploads endpoint. On published sites with `public` visibility, uploads referenced by published pages are publicly readable.
 
 ## Static export
 
@@ -350,16 +337,17 @@ Export your published docs as a self-contained static HTML ZIP for CDN deploymen
 ### Via CLI
 
 ```bash
-docplatform export --workspace my-docs --output ./my-docs-export.zip
+docplatform export --workspace {workspace-id} --output ./my-docs-export.zip
 ```
 
 ### Via API
 
 ```
-GET /api/v1/workspaces/{id}/export
+POST /api/v1/workspaces/{id}/export   # start the export
+GET  /api/v1/workspaces/{id}/export   # check status / download
 ```
 
-Returns a ZIP file containing:
+The export contains:
 
 - Rendered HTML for all published pages
 - `sitemap.xml` and `robots.txt`
@@ -371,9 +359,7 @@ Returns a ZIP file containing:
 Preview published docs locally without building a static export:
 
 ```bash
-docplatform preview --workspace my-docs --port 4000
+docplatform preview --workspace {workspace-id} --port 4000
 ```
 
 This starts a lightweight local server that renders pages in real-time — useful for reviewing changes before deploying.
-
-Pages with `published: false` are still accessible to authenticated workspace members at the `/p/` path — they're just excluded from the public navigation and sitemap.

--- a/guides/search.md
+++ b/guides/search.md
@@ -38,24 +38,22 @@ The search engine indexes:
 - **Page title** (boosted weight for ranking)
 - **Page description** (boosted weight)
 - **Full page content** (body text, code blocks, lists, etc.)
-- **Tags** (exact match boosting)
-- **Frontmatter metadata**
+- **Tags** (keyword field, boosted)
+- **Page path**
 
-### Search syntax
+### Matching behavior
 
-| Syntax | Example | Description |
+Queries are plain keywords — there is no special operator syntax:
+
+| Behavior | Example | Description |
 |---|---|---|
-| Keywords | `git sync` | Pages containing both "git" and "sync" |
-| Exact phrase | `"bidirectional sync"` | Pages with the exact phrase |
-| Prefix | `auth*` | Pages with words starting with "auth" |
-| Tag filter | `tag:api` | Pages tagged with "api" |
+| Keywords | `git sync` | Matches pages containing the terms across title, description, and body |
+| Fuzzy matching | `gti snyc` | Typos within a small edit distance still match (title tolerates more than body) |
+| Highlighting | — | Results include highlighted snippets showing where the match occurred |
 
 ## Permission filtering
 
-Search results are automatically filtered based on the current user's permissions:
-
-- **Workspace-scoped filtering** — results are limited to workspaces the user belongs to. This filtering happens at the search engine level.
-- **Page-level access** — pages with `access` rules are filtered post-query based on the user's role. A Viewer cannot find restricted admin-only pages through search, even if the content matches their query.
+Search is workspace-scoped: every query is constrained to the workspace it's issued against at the search-engine level, and the search endpoint requires read access to that workspace. There is no cross-workspace search.
 
 ## Indexing
 
@@ -75,31 +73,24 @@ There's a brief delay (typically under 1 second) between saving a page and the u
 If the search index gets out of sync (rare — usually after a crash or manual file manipulation), rebuild it:
 
 ```bash
-docplatform rebuild
+docplatform rebuild --workspace {workspace-id} --search
 ```
 
-This drops the existing search index and re-indexes all pages from the filesystem. The process runs in the background — the server remains available during rebuild.
+This re-indexes the workspace's pages from the filesystem (the `--search` flag includes the search index in the rebuild).
 
 ### Index health
 
-Check search index health with the doctor command:
+Check overall instance health (FS/DB consistency, broken wikilinks, backups, and more) with the doctor command:
 
 ```bash
 docplatform doctor
 ```
 
-The doctor reports:
-
-- Number of indexed documents vs. database page count
-- Orphaned index entries (indexed but no matching page)
-- Missing index entries (page exists but not indexed)
-- Index file size and last update timestamp
+If search results look stale or incomplete, rebuild the index with `docplatform rebuild --workspace {id} --search`.
 
 ## Search in published docs
 
-Published documentation sites include a search interface for visitors. The search input appears in the site header and uses the same Bleve engine.
-
-Public site search is scoped to published pages only — unpublished or restricted content never appears in public search results.
+Published documentation sites do **not** currently include a visitor-facing search interface — search is available to authenticated workspace members in the editor. For AI agents and crawlers, published sites expose `llms.txt` / `llms-full.txt` and `sitemap.xml` for content discovery instead.
 
 ## Search engine internals
 
@@ -122,8 +113,8 @@ Not all fields are weighted equally in relevance scoring:
 |---|---|---|
 | `title` | High (3.0x) | Page title (most relevant signal) |
 | `description` | Medium (1.5x) | Page description / summary |
-| `tags` | Exact match | Keyword field — exact tag matches boosted |
-| `body` | Normal | Full page content |
+| `tags` | Boosted (2.0x) | Keyword field — exact tag matches |
+| `body` | Normal (1.0x) | Full page content |
 | `path` | Keyword | File path — exact match only |
 
 This means a query matching a page's title ranks higher than the same query matching deep in the body text.

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Documentation platforms force you to choose: a polished web editor with vendor l
 | **Full-text search** | Embedded search engine with instant results. No external service to configure. |
 | **AI writing assist** | Rewrite, improve, shorten, or expand content with Claude or OpenAI. Chat with your docs for context-aware answers. |
 | **Built-in analytics** | GDPR-compliant pageview and search analytics with cookie consent — no third-party tracking required. |
-| **Stripe billing** | Three tiers (Community, Team, Business) with feature gating, free trials, and self-service portal. |
+| **Cloud edition available** | Prefer hosted? [app.valoryx.dev](https://app.valoryx.dev) runs DocPlatform Cloud with Free, Team ($29/mo), and Business ($79/mo) tiers. Community Edition stays self-hosted, free, and unlimited. |
 
 ## Who it's for
 
@@ -113,25 +113,24 @@ For the complete walkthrough, see the [Getting Started](getting-started/index.md
 
 - **Writing assist** — Rewrite, improve, shorten, or expand selected content using Claude or OpenAI
 - **Doc chat** — Multi-turn conversation about your workspace documentation
-- **MCP server (13 tools)** — Built-in Model Context Protocol server. Connect Claude Code, Claude Desktop, or Cursor to read, write, search, and maintain your docs autonomously via stdio
+- **MCP server (26 tools)** — Built-in Model Context Protocol server. Connect Claude Code, Claude Desktop, or Cursor to read, write, search, and maintain your docs autonomously via stdio or HTTP
 - **Context Graph API** — Structured knowledge graph for AI agents to navigate page relationships, tags, and wikilinks
 
 ### Analytics & billing
 
 - **Pageview analytics** — Track page views and top pages with GDPR-compliant cookie consent
 - **Search analytics** — Monitor search queries, top searches, and search frequency
-- **Stripe billing** — Community (free, unlimited), Free (1 workspace, 3 editors), Team ($29/mo), Business ($79/mo) with annual pricing (2 months free)
-- **Feature gating** — Analytics, custom domains, and advanced AI locked to paid plans
-- **14-day free trial** — Configurable trial period for paid plans
+- **Cloud plans** *(Cloud edition only)* — Free (1 workspace, 3 editors, 50 pages/workspace), Team ($29/mo), Business ($79/mo) with annual pricing (2 months free). Community Edition is self-hosted and unlimited — no billing code at all
+- **Plan limits** *(Cloud edition only)* — workspace, editor, and page caps enforced per plan; analytics reporting requires a plan with analytics
+- **14-day free trial** *(Cloud edition only)* — Configurable trial period for paid plans
 
 ### Operations
 
-- **Health diagnostics** — 10-point `doctor` command checks FS/DB consistency, search health, broken links
+- **Health diagnostics** — built-in `doctor` command runs 11 checks: FS/DB consistency, broken wikilinks, sync state, backups, and more
 - **Daily backups** — Automated SQLite backups with configurable retention
 - **Graceful shutdown** — Clean signal handling for zero-downtime deployments
 - **Structured logging** — JSON logs with request IDs for observability
 - **Durable job queue** — DB-backed async processing with retries for search indexing and maintenance
-- **Super admin dashboard** — Org/user management, impersonation, audit log, system health, GDPR tools
 - **Prometheus metrics** — Optional `/metrics` endpoint for monitoring integration
 - **Static site export** — Export and preview published docs locally
 

--- a/index.md
+++ b/index.md
@@ -126,7 +126,7 @@ For the complete walkthrough, see the [Getting Started](getting-started/index.md
 
 ### Operations
 
-- **Health diagnostics** — built-in `doctor` command runs 11 checks: FS/DB consistency, broken wikilinks, sync state, backups, and more
+- **Health diagnostics** — built-in `doctor` command runs 10 checks: FS/DB consistency, broken wikilinks, sync state, backups, and more
 - **Daily backups** — Automated SQLite backups with configurable retention
 - **Graceful shutdown** — Clean signal handling for zero-downtime deployments
 - **Structured logging** — JSON logs with request IDs for observability

--- a/reference/api.md
+++ b/reference/api.md
@@ -108,7 +108,7 @@ Auth endpoints use the unversioned `/api/auth/` prefix.
 POST /api/auth/register
 ```
 
-Create a new user account. The first user becomes Super Admin.
+Create a new user account. Registration creates the user's own organization (they become its Super Admin) plus a starter workspace. Terms acceptance is required. Rate limited to 5 registrations per hour per IP.
 
 **Request:**
 
@@ -116,25 +116,12 @@ Create a new user account. The first user becomes Super Admin.
 {
   "name": "Jane Smith",
   "email": "jane@example.com",
-  "password": "secure-password-here"
+  "password": "secure-password-here",
+  "terms_accepted": true
 }
 ```
 
-**Response:** `201 Created`
-
-```json
-{
-  "user": {
-    "id": "01HJK...",
-    "name": "Jane Smith",
-    "email": "jane@example.com",
-    "role": "superadmin"
-  },
-  "access_token": "eyJhbG...",
-  "refresh_token": "eyJhbG...",
-  "expires_in": 900
-}
-```
+**Response:** `201 Created` with the user object; sign in via `/api/auth/login` to obtain tokens.
 
 ### Login
 
@@ -376,18 +363,20 @@ DELETE /api/v1/content/{workspace}/{...path}
 ### Move/Rename page
 
 ```
-PUT /api/v1/content/{workspace}/{...path}
+PATCH /api/v1/content/{workspace}/{...path}
 ```
 
-Moving a page is a first-class operation. It preserves the stable `page_id`, updates all wikilinks across the workspace, and creates redirect aliases for the old URL.
+Moving a page is a first-class operation. It preserves the stable `page_id` and updates all wikilinks across the workspace.
 
-Include the `move_to` field in the request body:
+Include the new path in the request body:
 
 ```json
 {
   "move_to": "new/path/for/page"
 }
 ```
+
+(`POST /api/v1/content/{workspace}/move` exists as a compatibility alias.)
 
 ---
 
@@ -473,37 +462,16 @@ Reorder pages within a tree level. Requires write permission.
 GET /api/v1/workspaces/:id/search?q={query}
 ```
 
-Full-text search across workspaces the user has access to.
+Full-text search within one workspace. Requires read access to that workspace; every query is scoped to it at the search-engine level.
 
 **Query parameters:**
 
 | Parameter | Type | Description |
 |---|---|---|
 | `q` | string | Search query (required) |
-| `workspace` | string | Filter by workspace slug |
-| `tag` | string | Filter by tag |
-| `limit` | int | Max results (default: 20) |
+| `limit` | int | Max results (optional) |
 
-**Response:** `200 OK`
-
-```json
-{
-  "results": [
-    {
-      "page_id": "01HJK...",
-      "title": "Git Integration",
-      "path": "guides/git-integration.md",
-      "score": 0.95,
-      "snippet": "...bidirectional <mark>git sync</mark> lets your team..."
-    }
-  ],
-  "total": 5,
-  "query": "git sync",
-  "took_ms": 12
-}
-```
-
-Results are permission-filtered — users only see pages they have access to.
+Results include the matching pages with relevance scores and highlighted snippets.
 
 ---
 
@@ -536,7 +504,14 @@ Manually trigger a git pull + reconciliation. Requires Admin role.
 POST /api/git/webhook/:workspace_id
 ```
 
-A single endpoint that receives push event payloads from GitHub, GitLab, or Bitbucket. The payload format is auto-detected. No authentication header required — payloads are validated using the `GIT_WEBHOOK_SECRET` shared secret (HMAC-SHA256).
+A single endpoint that receives push event payloads from GitHub (`X-Hub-Signature-256`), GitLab (`X-Gitlab-Token`), or Bitbucket (`X-Hub-Signature`). Payloads are validated against the workspace's auto-generated **per-workspace webhook secret** (shown in Workspace Settings → Git). Pushes to branches other than the workspace's configured branch are ignored. Rate limited to 30/min.
+
+### Sync conflicts
+
+```
+GET  /api/v1/workspaces/:id/sync/conflicts/:conflict_id          — Inspect a sync conflict (read access)
+POST /api/v1/workspaces/:id/sync/conflicts/:conflict_id/resolve  — Apply a resolution (edit access; commits and pushes as you)
+```
 
 ---
 
@@ -556,27 +531,19 @@ Check whether AI features are enabled and which provider is configured.
 POST /api/v1/ai/writing-assist
 ```
 
-Rewrite, improve, shorten, or expand selected content.
+Transform text with one of six actions.
 
 **Request:**
 
 ```json
 {
-  "workspace_id": "01HJK...",
-  "operation": "improve",
-  "content": "This is the text to improve."
+  "action": "improve",
+  "content": "This is the text to improve.",
+  "language": "de"
 }
 ```
 
-**Operations:** `rewrite`, `improve`, `shorten`, `expand`
-
-**Response:** `200 OK`
-
-```json
-{
-  "result": "Here is the improved text..."
-}
-```
+**Actions:** `improve`, `simplify`, `expand`, `summarize`, `fix_grammar`, `translate` (only `translate` uses `language`). Unknown actions return a validation error. Returns `503 AI_DISABLED` when no AI provider is configured.
 
 ### Doc chat
 
@@ -590,7 +557,6 @@ Multi-turn conversation about workspace documentation.
 
 ```json
 {
-  "workspace_id": "01HJK...",
   "messages": [
     { "role": "user", "content": "How do I configure git sync?" }
   ]
@@ -599,15 +565,19 @@ Multi-turn conversation about workspace documentation.
 
 ---
 
-## Invitations
+## Invitations & share links
 
 ```
-GET    /api/v1/workspaces/:id/invitations              — List pending invitations (admin)
-POST   /api/v1/workspaces/:id/invitations              — Create invitation (admin)
+GET    /api/v1/workspaces/:id/invitations               — List pending invitations (admin)
+POST   /api/v1/workspaces/:id/invitations               — Create invitation (admin)
 DELETE /api/v1/workspaces/:id/invitations/:invitationId — Revoke invitation (admin)
+GET    /api/v1/workspaces/:id/share-links               — List share links (admin)
+POST   /api/v1/workspaces/:id/share-links               — Create a share link (admin)
+DELETE /api/v1/workspaces/:id/share-links/:linkId       — Revoke a share link (admin)
+POST   /api/v1/share-links/:token/use                   — Join a workspace via share link
 ```
 
-Invitations are email-based with a 7-day TTL. Accepted via `POST /api/auth/invitations/accept`.
+Invitations are email-based and accepted via `POST /api/auth/invitations/accept`. Inviting an Editor or Admin counts against the plan's seat limit (`403 PLAN_LIMIT_REACHED` when full).
 
 ---
 
@@ -624,9 +594,9 @@ API keys use the `dp_live_` prefix and are scoped to the organization.
 
 ---
 
-## Billing
+## Billing (Cloud edition only)
 
-Requires Stripe configuration. Disabled when `STRIPE_SECRET_KEY` is not set.
+These routes exist only in the Cloud edition that powers app.valoryx.dev — the Community binary contains no billing code and returns `404` for all of them.
 
 ```
 POST /api/v1/billing/checkout       — Create Stripe Checkout session
@@ -648,7 +618,7 @@ Receives Stripe webhook events (signature-verified). Handles subscription lifecy
 
 ## Analytics
 
-GDPR-compliant analytics with cookie consent. Feature-gated to paid plans.
+GDPR-compliant analytics with cookie consent. Reporting requires a plan with the analytics feature (included in Community Edition and Cloud Team/Business; not in Cloud Free — returns `403 PLAN_LIMIT`).
 
 ```
 POST /api/analytics/consent                          — Record GDPR consent
@@ -695,10 +665,62 @@ Scan a workspace for documentation quality issues. Returns readability scores, d
 ## Static export
 
 ```
-GET /api/v1/workspaces/:id/export
+POST /api/v1/workspaces/:id/export   — Start the export
+GET  /api/v1/workspaces/:id/export   — Check status / download
 ```
 
 Export all published pages as a static HTML ZIP file.
+
+---
+
+## Outbound webhooks (not yet active)
+
+Workspace admins can manage outbound webhook definitions:
+
+```
+GET    /api/v1/workspaces/:id/webhooks                 — List webhooks (admin)
+POST   /api/v1/workspaces/:id/webhooks                 — Create webhook (admin)
+GET    /api/v1/workspaces/:id/webhooks/:wid            — Get webhook (admin)
+PUT    /api/v1/workspaces/:id/webhooks/:wid            — Update webhook (admin)
+DELETE /api/v1/workspaces/:id/webhooks/:wid            — Delete webhook (admin)
+GET    /api/v1/workspaces/:id/webhooks/:wid/deliveries — Delivery log (admin)
+```
+
+> ⚠️ **Outbound webhook delivery is not yet active.** Webhook definitions can be created and validated (URLs are SSRF-checked), but events are **not currently delivered** — the deliveries list will remain empty. Use the WebSocket event stream or the activity feed for change notifications until delivery ships.
+
+---
+
+## Comments
+
+```
+GET    /api/v1/workspaces/:id/comments?page={path}  — List comments (filter by page)
+POST   /api/v1/workspaces/:id/comments              — Create a comment (commenter+)
+PUT    /api/comments/:id                            — Edit a comment
+DELETE /api/comments/:id                            — Delete a comment
+POST   /api/comments/:id/resolve                    — Resolve a thread
+POST   /api/comments/:id/unresolve                  — Reopen a thread
+```
+
+---
+
+## Activity feed
+
+```
+GET /api/v1/workspaces/:id/activity?limit=50&action=page_created  — Workspace activity
+GET /api/v1/workspaces/:id/page-activity?page={path}              — Per-page history
+```
+
+---
+
+## GDPR / data portability (Cloud edition)
+
+```
+GET    /api/v1/users/me/export      — Export your personal data
+DELETE /api/v1/users/me             — Delete your account (password-gated)
+GET    /api/v1/orgs/:handle/export  — Export org data (org super admin)
+```
+
+Export endpoints are rate-limited to once per 24 hours.
 
 ---
 
@@ -732,72 +754,9 @@ PATCH /api/v1/users/me/onboarding  — Update onboarding state
 
 ---
 
-## Super admin panel
-
-These endpoints require the Super Admin role. All prefixed with `/api/v1/admin/`.
-
-### Organization management
-
-```
-GET  /api/v1/admin/orgs                          — List all organizations
-GET  /api/v1/admin/orgs/:id                      — Get organization details
-PUT  /api/v1/admin/orgs/:id/plan                 — Change organization plan
-POST /api/v1/admin/orgs/:id/subscription/override — Override subscription
-PUT  /api/v1/admin/orgs/:id/rate-limits          — Override rate limits
-POST /api/v1/admin/orgs/:id/export               — Export org data (GDPR)
-```
-
-### User management
-
-```
-GET    /api/v1/admin/users              — List all users
-GET    /api/v1/admin/users/:id          — Get user details
-POST   /api/v1/admin/users/:id/impersonate — Impersonate user
-POST   /api/v1/admin/users/:id/export   — Export user data (GDPR)
-DELETE /api/v1/admin/users/:id          — Delete user (GDPR right to erasure)
-```
-
-### Audit log
-
-```
-GET /api/v1/admin/audit-log    — Query audit log (filterable by user, action, resource, date range)
-```
-
-### Billing overview
-
-```
-GET /api/v1/admin/billing/overview       — Platform-wide billing summary
-GET /api/v1/admin/billing/subscriptions  — All active subscriptions
-GET /api/v1/admin/billing/events         — Webhook event log
-```
-
-### Domain management
-
-```
-GET    /api/v1/admin/domains              — List all custom domains
-POST   /api/v1/admin/domains/:id/verify   — Verify domain DNS
-POST   /api/v1/admin/domains/:id/provision — Provision TLS certificate
-DELETE /api/v1/admin/domains/:id          — Delete domain
-```
-
-### System health
-
-```
-GET /api/v1/admin/system/health    — System health metrics (disk, memory, uptime, DB stats)
-```
-
-### Platform analytics
-
-```
-GET /api/v1/admin/analytics/overview  — Platform-wide analytics overview
-GET /api/v1/admin/analytics/growth    — Platform growth metrics
-```
-
----
-
 ## MCP server
 
-DocPlatform includes a built-in MCP (Model Context Protocol) server exposing **24 tools** for AI agent integration. Two transports are available:
+DocPlatform includes a built-in MCP (Model Context Protocol) server exposing **26 tools** for AI agent integration. Two transports are available:
 
 ```bash
 # stdio (single workspace, for local AI tools)
@@ -807,7 +766,7 @@ docplatform mcp --workspace my-docs --api-key dp_live_abc123
 docplatform mcp-server --addr :8081
 ```
 
-### MCP tools (24)
+### MCP tools (26)
 
 | Tool | Category | Description |
 |---|---|---|
@@ -828,6 +787,7 @@ docplatform mcp-server --addr :8081
 | `docplatform_update_theme` | Settings | Update theme (default, dark, forest, rose, amber, minimal, corporate) |
 | `docplatform_create_workspace` | Management | Create a new workspace |
 | `docplatform_get_workspace` | Management | Workspace details, role, git sync, publish settings |
+| `docplatform_publish_workspace` | Management | Enable/disable the workspace's published site |
 | `docplatform_list_versions` | Versioning | List documentation versions |
 | `docplatform_create_version` | Versioning | Create a named version (e.g., v2.0) |
 | `docplatform_export` | Export | Export workspace as static site |
@@ -835,6 +795,7 @@ docplatform mcp-server --addr :8081
 | `docplatform_get_activity` | Activity | Recent workspace activity feed |
 | `docplatform_list_comments` | Comments | Threaded comments on a page |
 | `docplatform_add_comment` | Comments | Add a comment with @mentions and threading |
+| `docplatform_resolve_sync_conflict` | Sync | Resolve a git-sync conflict (conditional — requires server-URL configuration) |
 
 All tools respect workspace permissions and require a valid API key. See the [MCP Server guide](../guides/mcp.md) for complete setup and tool reference.
 
@@ -846,7 +807,7 @@ All tools respect workspace permissions and require a valid API key. See the [MC
 GET /metrics
 ```
 
-Available when `FF_METRICS=true`. Requires Super Admin authentication. Exposes HTTP latency histograms, request counts, auth event counters, and more.
+Available on the main port when `FF_METRICS=true` (platform-owner authentication required). Alternatively, set `METRICS_PORT` to expose an unauthenticated `/metrics` listener bound to `127.0.0.1:{port}` for local scraping.
 
 ---
 
@@ -855,45 +816,28 @@ Available when `FF_METRICS=true`. Requires Super Admin authentication. Exposes H
 These endpoints use the unversioned `/api/` prefix and do not require authentication.
 
 ```
-GET /api/health    → 200 OK { "status": "ok", "db": "ok", "git": "ok" }
-GET /api/ready     → 200 OK { "status": "ready" }
+GET /api/health    → 200 OK { "status": "ok", "version": "v0.10.0" }
+GET /api/ready     → 200 OK { "status": "ready", "checks": { ... } }
 ```
 
-The `/api/ready` endpoint returns `503 Service Unavailable` while the initial reconciliation is in progress (startup).
+The `/api/ready` endpoint reports readiness of the database, git engine, and job outbox.
 
 ---
 
 ## Error format
 
-All error responses follow [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) (Problem Details for HTTP APIs):
+Error responses share a single JSON shape:
 
 ```json
 {
-  "type": "https://docplatform.io/errors/conflict-detected",
-  "title": "Conflict Detected",
-  "status": 409,
-  "detail": "Content hash mismatch. The page was modified by another user.",
-  "current_hash": "sha256:def456...",
-  "your_hash": "sha256:abc123...",
-  "modified_by": "jane@example.com",
-  "modified_at": "2025-01-16T14:30:00Z"
+  "error": "VALIDATION_ERROR",
+  "message": "title is required",
+  "details": { "field": "title" },
+  "request_id": "01HJK..."
 }
 ```
 
-Validation errors include a `fields` array:
-
-```json
-{
-  "type": "https://docplatform.io/errors/validation-error",
-  "title": "Validation Error",
-  "status": 400,
-  "detail": "One or more fields are invalid.",
-  "fields": [
-    { "field": "content", "error": "required" },
-    { "field": "lastKnownHash", "error": "must be 64 hex characters" }
-  ]
-}
-```
+`details` is optional; `request_id` correlates with the server logs.
 
 ### Common error codes
 
@@ -902,65 +846,32 @@ Validation errors include a `fields` array:
 | `400` | `VALIDATION_ERROR` | Invalid request body or parameters |
 | `401` | `UNAUTHORIZED` | Missing or invalid authentication |
 | `403` | `FORBIDDEN` | Insufficient permissions |
+| `403` | `PLAN_LIMIT_REACHED` | Plan limit hit (Cloud edition) |
 | `404` | `NOT_FOUND` | Resource not found (or no read access) |
-| `409` | `CONFLICT_DETECTED` | Concurrent modification detected |
-| `422` | `UNPROCESSABLE` | Valid syntax but semantic error (e.g., circular wikilink) |
+| `409` | `CONFLICT` | Concurrent modification detected |
 | `429` | `RATE_LIMITED` | Too many requests |
 | `500` | `INTERNAL_ERROR` | Server error (check logs) |
-| `503` | `SERVICE_UNAVAILABLE` | Reconciliation in progress |
 
 ## Pagination
 
-Content listing endpoints use **cursor-based pagination** with ULIDs for stable results even when content is being added or deleted.
+List endpoints accept `limit` and `cursor` query parameters and return a `next_cursor` when more results are available:
 
-**Query parameters:**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `cursor` | string | — | ULID of the last item from the previous page. Omit for the first page. |
-| `limit` | int | 20 | Number of results per page (max: 100) |
-
-**Response metadata:**
-
-```json
-{
-  "data": [...],
-  "next_cursor": "01HJK...",
-  "has_more": true
-}
+```
+GET /api/v1/workspaces/:id/activity?limit=50&cursor={cursor}
 ```
 
-Pass `next_cursor` as the `cursor` parameter in the next request. When `has_more` is `false`, you've reached the end.
+Pass the returned `next_cursor` as `cursor` in the next request.
 
 ---
 
-## Asset uploads
+## Uploads
 
 ```
-POST /api/v1/content/{workspace}/assets
+POST /api/v1/content/{workspace}/uploads             — Upload a file (multipart/form-data, field "file")
+GET  /api/v1/content/{workspace}/uploads/{filename}  — Serve an uploaded file
 ```
 
-Upload images and files to a workspace. Assets are stored in the workspace's `assets/` directory and committed to git if sync is enabled.
-
-**Request:** `multipart/form-data` with a `file` field.
-
-**Limits:**
-
-| Constraint | Value |
-|---|---|
-| Max file size | 10 MB |
-| Accepted types | PNG, JPG, GIF, SVG, WebP, PDF |
-
-**Response:** `201 Created`
-
-```json
-{
-  "path": "assets/screenshot-2025-01-15.png",
-  "url": "/api/v1/content/{workspace}/assets/screenshot-2025-01-15.png",
-  "size": 245760,
-  "content_type": "image/png"
-}
-```
+Uploads require edit permission. Files referenced by published pages on a `public`-visibility site are publicly readable. Upload size is bounded by the global 10 MB request body limit, with upload-bomb protection on archives.
 
 ---
 
@@ -1031,7 +942,7 @@ WebSocket connections use an HttpOnly cookie mechanism to avoid exposing tokens 
 
 **Response:** `200 OK`
 
-Sets a `dp_ws_token` HttpOnly cookie (valid for **30 seconds**, single-use). No JSON body is returned.
+Sets a `dp_ws_token` HttpOnly, SameSite=Strict cookie (valid for 1 hour).
 
 Connect via:
 
@@ -1039,7 +950,7 @@ Connect via:
 ws://localhost:3000/ws
 ```
 
-The browser sends the `dp_ws_token` cookie automatically. The server validates it, establishes the WebSocket, and clears the cookie.
+The browser sends the `dp_ws_token` cookie automatically; the server validates it and establishes the WebSocket.
 
 ### Server events
 
@@ -1055,27 +966,18 @@ The browser sends the `dp_ws_token` cookie automatically. The server validates i
 | `page-moved` | `{workspace_id, old_path, new_path, actor}` | A page is moved/renamed |
 | `bulk-sync` | `{workspace_id, changed_count, paths[]}` | Multiple files synced in one pull |
 
-### Client messages
-
-```json
-{"type": "subscribe", "workspace_id": "01HJK..."}
-{"type": "unsubscribe", "workspace_id": "01HJK..."}
-```
-
 ---
 
 ## Security headers
 
-DocPlatform sets the following headers on all responses:
+DocPlatform sets the following headers:
 
 | Header | Value |
 |---|---|
 | `X-Content-Type-Options` | `nosniff` |
-| `X-Frame-Options` | `DENY` |
-| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'` |
-| `X-Request-ID` | ULID (unique per request, included in error responses and logs) |
+| `Content-Security-Policy` | Set per surface (API, published sites, SPA) with nonce-based policies |
 
-Published docs additionally set:
+`HSTS` and `X-Frame-Options` are left to the reverse proxy. Published docs additionally set:
 
 | Header | Value |
 |---|---|
@@ -1086,21 +988,26 @@ Published docs additionally set:
 
 ## Rate limiting
 
-Rate limits are tier-based and scale with your plan. Token bucket algorithm, per-org for authenticated requests, per-IP for unauthenticated.
+HTTP rate limits are per category — per-org for authenticated requests, per-IP for unauthenticated:
 
-| Endpoint category | Community / Free | Team | Business | Enterprise |
-|---|---|---|---|---|
-| Content read | 100/min | 300/min | 600/min | 1,200/min |
-| Content write | 20/min | 60/min | 120/min | 300/min |
-| Search | 30/min | 100/min | 200/min | 500/min |
-| Auth (login, register, reset) | 5/min per IP | 5/min | 5/min | 5/min |
-| Git webhooks | 10/min | 30/min | 60/min | 120/min |
-| Published docs (public) | 1,000/min per IP | 3,000/min | 6,000/min | Unlimited |
+| Endpoint category | Limit |
+|---|---|
+| Content read | 300/min |
+| Content write | 60/min |
+| Search | 60/min |
+| Auth endpoints | 20/min |
+| Registration | 5/hour per IP |
+| Password reset | 5 per 15 min |
+| Git webhooks | 30/min |
+| Published docs (public) | 600/min |
+| Data export (GDPR) | 1 per 24 h |
+
+(The MCP transport has its own per-plan limits — see the [MCP guide](../guides/mcp.md).)
 
 Rate limit responses include these headers:
 
 ```
-X-RateLimit-Limit: 100
+X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 0
 X-RateLimit-Reset: 1234567890
 Retry-After: 30

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -32,10 +32,9 @@ docplatform serve [flags]
 
 ### Behavior
 
-- Loads environment variables from `.env` file (if present)
+- Reads configuration from environment variables (there is no config file)
 - Initializes SQLite database with WAL mode
 - Runs pending database migrations
-- Loads custom RBAC permission policies into memory
 - Builds or opens the Bleve search index
 - Starts the git sync engine for all configured workspaces
 - Starts the backup scheduler (if enabled)
@@ -45,12 +44,11 @@ docplatform serve [flags]
 
 When `docplatform serve` runs, the following happens in order:
 
-1. Load config (environment variables + `.env` file + defaults)
+1. Load config from environment variables (+ defaults)
 2. Open SQLite database (WAL mode) and run pending migrations
-3. Seed default organization if this is a first run
-4. Initialize services: Content Ledger, Git Engine (worker pool of 4), Search Engine, Permission Service, Auth Service (RS256 JWT, Argon2id, WebAuthn), WebSocket Hub, Billing/License Service (Stripe), Analytics Collector, AI Service
-5. Start background goroutines: WebSocket hub, git sync polling, backup scheduler, durable job worker, analytics collector, telemetry (if enabled)
-6. Begin listening on the configured host:port
+3. Initialize services: Content Ledger, Git Engine, Search Engine, Permission Service, Auth Service (RS256 JWT, Argon2id, WebAuthn), WebSocket Hub, License Service, Analytics Collector, AI Service (if configured)
+4. Start background goroutines: WebSocket hub, git sync polling, backup scheduler, job worker, analytics collector, telemetry (if enabled)
+5. Begin listening on the configured port
 
 Read requests are served immediately. If workspaces have existing content, reconciliation runs in the background without blocking.
 
@@ -86,7 +84,7 @@ docplatform serve --port 8080
 ### Output
 
 ```
-INFO  Server starting            port=3000 version=v0.5.2
+INFO  Server starting            port=3000 version=v0.10.0
 INFO  Database initialized       path=.docplatform/data.db wal=true
 INFO  Migrations applied         count=1
 INFO  Search index ready         documents=42
@@ -113,7 +111,10 @@ docplatform init [flags]
 | `--slug` | Yes | — | URL-safe identifier (used in published docs URL) |
 | `--git-url` | No | — | Remote git repository URL (SSH or HTTPS) |
 | `--branch` | No | `main` | Git branch to sync |
-| `--data-dir` | No | `.docplatform` | Data directory path |
+
+The data directory comes from the `DATA_DIR` environment variable (default `.docplatform`) — this applies to every command; there is no `--data-dir` flag.
+
+> CLI-created workspaces attach to a server-level default organization, not to a web account's organization. See [Your First Workspace](../getting-started/first-workspace.md).
 
 ### Behavior
 
@@ -167,19 +168,16 @@ docplatform rebuild [flags]
 
 | Flag | Required | Default | Description |
 |---|---|---|---|
-| `--workspace` | Yes | — | ULID of the workspace to rebuild (required). |
-| `--search` | No | `false` | Also drop and rebuild the Bleve search index |
-| `--data-dir` | No | `.docplatform` | Data directory path |
+| `--workspace`, `-w` | Yes | — | ULID of the workspace to rebuild (required). |
+| `--search` | No | `false` | Also rebuild the Bleve search index |
 
 ### Behavior
 
-1. Creates a backup of the current database
-2. Drops the `pages` table
-3. Scans the filesystem for all `.md` files in workspace `docs/` directories
-4. Parses frontmatter and content for each file
-5. Inserts page records into the database
-6. Rebuilds the Bleve search index
-7. Reports reconciliation results
+1. Scans the filesystem for all `.md` files in the workspace directory
+2. Parses frontmatter and content for each file
+3. Reconciles page records in the database (three-tier matching: frontmatter ID → path → content hash)
+4. Rebuilds the search index when `--search` is passed
+5. Reports reconciliation results
 
 ### When to use
 
@@ -198,13 +196,10 @@ docplatform rebuild --workspace 01KJJ10NTF31Z1QJTG4ZRQZ2Z2
 ### Output
 
 ```
-INFO  Backup created             path=.docplatform/backups/pre-rebuild-20250115.db
 INFO  Rebuilding workspace       id=01KJJ10NTF... name="API Docs"
-INFO  Scanning filesystem        path=.docplatform/workspaces/01KJJ.../docs/
 INFO  Pages found                count=42
-INFO  Database rebuilt            inserted=42 updated=0 orphaned=3
-INFO  Search index rebuilt        documents=42
-INFO  Ghost recovery             matched=2 unmatched=1
+INFO  Database rebuilt           inserted=42 updated=0 orphaned=3
+INFO  Search index rebuilt       documents=42
 INFO  Rebuild complete
 ```
 
@@ -214,7 +209,7 @@ INFO  Rebuild complete
 
 ## `docplatform doctor`
 
-Run 9 diagnostic checks on the platform health.
+Run 11 diagnostic checks on the platform health.
 
 ```bash
 docplatform doctor [flags]
@@ -225,21 +220,22 @@ docplatform doctor [flags]
 | Flag | Required | Default | Description |
 |---|---|---|---|
 | `--bundle` | No | `false` | Create a ZIP file containing diagnostic output for support |
-| `--data-dir` | No | `.docplatform` | Data directory path |
 
 ### Checks
 
 | # | Check | Description |
 |---|---|---|
-| 1 | **Database connection** | SQLite file exists, is readable, WAL mode enabled |
-| 2 | **Schema version** | Migrations are up to date |
-| 3 | **FS/DB consistency** | Every file in `docs/` has a database record, and vice versa |
-| 4 | **Orphaned files** | Files on disk without a database record |
-| 5 | **Orphaned records** | Database records without a file on disk |
-| 6 | **Search index health** | Bleve index document count matches page count |
-| 7 | **Broken internal links** | Markdown links pointing to non-existent pages |
-| 8 | **Frontmatter validity** | All pages have valid YAML frontmatter with a title |
-| 9 | **Git remote connectivity** | If git is configured, can the remote be reached? |
+| 1 | **config** | Configuration loads and validates |
+| 2 | **data_dir** | The data directory exists and is a directory |
+| 3 | **database** | Main database reachable, migrations current |
+| 4 | **analytics_db** | Analytics database reachable |
+| 5 | **git** | Native `git` binary available in PATH (warning if missing) |
+| 6 | **workspace_dirs** | Every workspace has its content directory on disk |
+| 7 | **orphaned_dirs** | Directories on disk without a workspace record |
+| 8 | **sync_state** | Git sync state is consistent |
+| 9 | **fs_db_consistency** | Files on disk match database page records |
+| 10 | **broken_wikilinks** | Wikilinks pointing to non-existent pages |
+| 11 | **backups** | Backup directory present and recent backups exist |
 
 ### Exit codes
 
@@ -266,38 +262,28 @@ docplatform doctor
 DocPlatform Health Check
 ========================
 
-✓ Database connection          OK (WAL mode, 42 pages, 3 users)
-✓ Schema version               OK (v1, up to date)
-✓ FS/DB consistency            OK (42 files, 42 records)
-✓ Orphaned files               OK (0 found)
-✓ Orphaned records             OK (0 found)
-✓ Search index health          OK (42 indexed, 42 expected)
-⚠ Broken internal links        WARNING (2 broken links found)
-  → guides/editor.md:15 → "old-page.md" (file not found)
-  → api/endpoints.md:42 → "deprecated.md" (file not found)
-✓ Frontmatter validity         OK (42/42 valid)
-✓ Git remote connectivity      OK (git@github.com:your-org/docs.git)
+✓ config                OK
+✓ data_dir              OK (.docplatform exists)
+✓ database              OK (migrations current)
+✓ analytics_db          OK
+✓ git                   OK (binary found)
+✓ workspace_dirs        OK
+✓ orphaned_dirs         OK (0 found)
+✓ sync_state            OK
+✓ fs_db_consistency     OK (42 files, 42 records)
+⚠ broken_wikilinks      WARNING (2 broken links found)
+✓ backups               OK
 
-Result: 8/9 passed, 1 warning
+Result: 10/11 passed, 1 warning
 ```
 
 ### Bundle mode
 
 ```bash
 docplatform doctor --bundle
-# Creates: docplatform-doctor-20250115.zip
 ```
 
-The bundle is saved to `{DATA_DIR}/diagnostics/docplatform-diagnostics-{timestamp}.zip` and contains:
-
-- `report.json` — structured diagnostic results
-- Schema information (table definitions, no row data)
-- File listing (paths and sizes, no content)
-- System info (OS, architecture, Go version)
-- Last 1,000 lines of error logs
-- Server version and configuration (with secrets redacted)
-
-The bundle **never** includes page content, passwords, tokens, or private keys.
+The bundle is saved to `{DATA_DIR}/diagnostics-{timestamp}.zip` and contains sanitized system information and the structured check results for support requests. It never includes page content, passwords, tokens, or private keys.
 
 ---
 
@@ -313,9 +299,8 @@ docplatform export [flags]
 
 | Flag | Required | Default | Description |
 |---|---|---|---|
-| `--workspace` | Yes | — | Workspace ID (ULID) to export |
-| `--output` | No | `{workspace}-export.zip` | Output ZIP file path |
-| `--data-dir` | No | `.docplatform` | Data directory path |
+| `--workspace`, `-w` | Yes | — | Workspace ID (ULID) to export |
+| `--output`, `-o` | No | `{site-slug}-export.zip` | Output ZIP file path |
 
 ### Behavior
 
@@ -327,7 +312,7 @@ docplatform export [flags]
 ### Example
 
 ```bash
-docplatform export --workspace my-docs --output ./dist/my-docs.zip
+docplatform export --workspace 01KJJ10NTF31Z1QJTG4ZRQZ2Z2 --output ./dist/my-docs.zip
 ```
 
 The resulting ZIP can be deployed to any static file host (Netlify, Vercel, S3, GitHub Pages, Cloudflare Pages).
@@ -346,9 +331,8 @@ docplatform preview [flags]
 
 | Flag | Required | Default | Description |
 |---|---|---|---|
-| `--workspace` | Yes | — | Workspace ID (ULID) to preview |
-| `--port` | No | `4000` | HTTP listen port |
-| `--data-dir` | No | `.docplatform` | Data directory path |
+| `--workspace`, `-w` | Yes | — | Workspace ID (ULID) to preview |
+| `--port`, `-p` | No | `4000` | HTTP listen port |
 
 ### Behavior
 
@@ -378,11 +362,10 @@ docplatform mcp [flags]
 |---|---|---|---|
 | `--workspace`, `-w` | Yes | — | Workspace slug to expose |
 | `--api-key` | Yes | — | API key for authentication (`dp_live_...`). Also accepts `DOCPLATFORM_API_KEY` env var |
-| `--data-dir` | No | `.docplatform` | Data directory path |
 
 ### Behavior
 
-Starts an MCP server on stdin/stdout, scoped to a single workspace and authenticated via API key. Exposes 24 tools for content CRUD, search, quality scanning, versioning, export, and more. Compatible with any MCP client (Claude Desktop, Claude Code, Cursor, VS Code).
+Starts an MCP server on stdin/stdout, scoped to a single workspace and authenticated via API key. Exposes 26 tools for content CRUD, search, quality scanning, versioning, export, and more. Compatible with any MCP client (Claude Desktop, Claude Code, Cursor, VS Code).
 
 ### Example
 
@@ -421,7 +404,6 @@ docplatform mcp-server [flags]
 |---|---|---|---|
 | `--addr` | No | `:8081` | Listen address (e.g., `:8081`, `0.0.0.0:9090`) |
 | `--cors-origins` | No | claude.ai, cursor | Allowed CORS origins (comma-separated) |
-| `--data-dir` | No | `.docplatform` | Data directory path |
 
 ### Behavior
 
@@ -446,6 +428,25 @@ Authorization: Bearer dp_live_abc123
 
 ---
 
+## `docplatform reset-password`
+
+Generate a one-time password-reset link for a user — useful when email isn't configured or a user is locked out.
+
+```bash
+docplatform reset-password --email user@example.com
+```
+
+### Flags
+
+| Flag | Required | Default | Description |
+|---|---|---|---|
+| `--email` | Yes | — | Email address of the user |
+| `--base-url` | No | `BASE_URL` env or `http://localhost:3000` | Base URL used to build the reset link |
+
+The printed link is single-use and expires after 1 hour.
+
+---
+
 ## `docplatform version`
 
 Print version, commit hash, and build date.
@@ -457,7 +458,7 @@ docplatform version
 ### Output
 
 ```
-docplatform v0.5.2 (commit: abc1234, built: 2026-03-08T10:00:00Z)
+docplatform v0.10.0 (commit: 5738520, built: 2026-05-16T17:52:38Z)
 ```
 
 The version information is embedded at build time via linker flags. Useful for verifying which release is deployed and for support requests.

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -209,7 +209,7 @@ INFO  Rebuild complete
 
 ## `docplatform doctor`
 
-Run 11 diagnostic checks on the platform health.
+Run 10 diagnostic checks on the platform health.
 
 ```bash
 docplatform doctor [flags]
@@ -231,11 +231,10 @@ docplatform doctor [flags]
 | 4 | **analytics_db** | Analytics database reachable |
 | 5 | **git** | Native `git` binary available in PATH (warning if missing) |
 | 6 | **workspace_dirs** | Every workspace has its content directory on disk |
-| 7 | **orphaned_dirs** | Directories on disk without a workspace record |
-| 8 | **sync_state** | Git sync state is consistent |
-| 9 | **fs_db_consistency** | Files on disk match database page records |
-| 10 | **broken_wikilinks** | Wikilinks pointing to non-existent pages |
-| 11 | **backups** | Backup directory present and recent backups exist |
+| 7 | **sync_state** | Git sync state is consistent |
+| 8 | **fs_db_consistency** | Files on disk match database page records |
+| 9 | **broken_wikilinks** | Wikilinks pointing to non-existent pages |
+| 10 | **backups** | Backup directory present and recent backups exist |
 
 ### Exit codes
 
@@ -268,13 +267,12 @@ DocPlatform Health Check
 ✓ analytics_db          OK
 ✓ git                   OK (binary found)
 ✓ workspace_dirs        OK
-✓ orphaned_dirs         OK (0 found)
 ✓ sync_state            OK
 ✓ fs_db_consistency     OK (42 files, 42 records)
 ⚠ broken_wikilinks      WARNING (2 broken links found)
 ✓ backups               OK
 
-Result: 10/11 passed, 1 warning
+Result: 9/10 passed, 1 warning
 ```
 
 ### Bundle mode

--- a/reference/troubleshooting.md
+++ b/reference/troubleshooting.md
@@ -86,9 +86,9 @@ docplatform serve
 
 ### Git sync shows "no changes" but files were updated
 
-**Cause:** Changes were made to files outside the `docs/` directory, which DocPlatform doesn't index.
+**Cause:** The updated files are not Markdown (only `.md` files are indexed), or the push went to a branch other than the workspace's configured branch.
 
-**Solution:** Ensure your Markdown files are in the workspace's `docs/` directory. Files in other directories are preserved in git but not tracked by DocPlatform.
+**Solution:** Verify the changes are `.md` files on the configured branch. Non-Markdown files are preserved in git but not tracked by DocPlatform.
 
 ### Conflict: HTTP 409 on save
 
@@ -148,21 +148,11 @@ curl -X POST http://localhost:3000/api/auth/refresh \
 3. Ensure the `OIDC_*_CLIENT_ID` and `OIDC_*_CLIENT_SECRET` environment variables are set correctly
 4. Restart the server after changing OIDC environment variables
 
-### First user is not Super Admin
+### A teammate registered but can't see our workspace
 
-**Cause:** The database already contained user records from a previous installation.
+**Cause:** Registering creates a **new organization** for that user — they are Super Admin of their own org, not a member of yours.
 
-**Solution:**
-
-```bash
-# WARNING: This deletes all data
-docplatform serve  # stop first
-rm .docplatform/data.db
-docplatform serve
-# Register your admin account
-```
-
-Only do this on a fresh installation. For existing installations, use the database to update user roles directly (advanced).
+**Solution:** Invite them to your workspace (**Workspace Settings → Members → Invite**). They'll get access with the role you choose; their own organization is unaffected.
 
 ## Search
 
@@ -173,11 +163,11 @@ Only do this on a fresh installation. For existing installations, use the databa
 **Solution:**
 
 ```bash
-# Check search health
+# Check overall instance health
 docplatform doctor
 
-# If the index is out of sync, rebuild
-docplatform rebuild
+# If the index is out of sync, rebuild it
+docplatform rebuild --workspace {workspace-id} --search
 ```
 
 ### Search results are stale (don't reflect recent edits)
@@ -187,7 +177,7 @@ docplatform rebuild
 **Solution:** Wait a moment and retry. If the issue persists:
 
 1. Check server logs for indexing errors
-2. Run `docplatform rebuild` to force a full re-index
+2. Run `docplatform rebuild --workspace {workspace-id} --search` to force a full re-index
 
 ### Search is slow
 
@@ -196,8 +186,7 @@ docplatform rebuild
 **Solution:**
 
 - Use more specific search terms
-- Use tag filters to narrow the scope
-- Future releases will support Meilisearch for high-performance search
+- Future releases may offer Meilisearch for high-performance search
 
 ## Data recovery
 
@@ -206,12 +195,12 @@ docplatform rebuild
 **Option 1: Git history** (if git sync is enabled)
 
 ```bash
-cd .docplatform/workspaces/{id}/docs/
+cd .docplatform/workspaces/{id}/
 git log --all -- path/to/deleted-page.md
 git checkout <commit-hash> -- path/to/deleted-page.md
 ```
 
-Then run `docplatform rebuild` to re-index.
+Then run `docplatform rebuild --workspace {id} --search` to re-index.
 
 **Option 2: Database backup**
 
@@ -237,12 +226,10 @@ docplatform serve
    ```bash
    cp .docplatform/backups/{latest}.db .docplatform/data.db
    ```
-4. If no backup is available, rebuild from the filesystem:
+4. If no backup is available, start the server (a fresh database is created and migrated), then rebuild each workspace from its files:
    ```bash
-   rm .docplatform/data.db
-   docplatform rebuild
+   docplatform rebuild --workspace {workspace-id} --search
    ```
-5. Start the server
 
 The filesystem (`.md` files) is the source of truth. Even if the database is lost, `rebuild` recreates it from your files.
 
@@ -256,49 +243,31 @@ The filesystem (`.md` files) is the source of truth. Even if the database is los
 
 ## Frontmatter errors
 
-### Page becomes inaccessible after frontmatter edit
+### Page misbehaves after a frontmatter edit
 
-**Cause:** Invalid YAML in the frontmatter block. DocPlatform uses **strict mode** by default — if frontmatter parsing fails, the page is restricted to Admin access only to prevent a YAML typo from accidentally making a private page public.
-
-**Symptoms:**
-
-- Page disappears from search results
-- Page excluded from published docs
-- Non-admin users get 403 Forbidden
-- Admin sees a warning banner on the page
+**Cause:** Invalid YAML in the frontmatter block (common issues: missing quotes around values with colons, incorrect indentation, unclosed brackets).
 
 **Solution:**
 
-1. Sign in as an Admin or Super Admin
-2. Open the affected page in the web editor
-3. Switch to raw Markdown mode (`</>` toggle)
-4. Fix the YAML frontmatter (common issues: missing quotes around values with colons, incorrect indentation, unclosed brackets)
-5. Save — the page is re-indexed and access restored
+1. Open the affected page in the web editor
+2. Switch to raw Markdown mode (`</>` toggle)
+3. Fix the YAML and save
 
 **If you can't access the web editor**, fix the file directly on disk:
 
 ```bash
 # Edit the Markdown file
-nano .docplatform/workspaces/{id}/docs/{path-to-page}.md
+nano .docplatform/workspaces/{id}/{path-to-page}.md
 
 # Rebuild to re-index
-docplatform rebuild
+docplatform rebuild --workspace {id} --search
 ```
 
-### Understanding frontmatter error modes
-
-| Mode | Behavior on invalid YAML | When to use |
-|---|---|---|
-| **Strict** (default) | Page restricted to Admin only, excluded from search and published docs | Production — prevents accidental exposure |
-| **Lenient** | Keep last-known-good frontmatter from database, show warning | Development — less disruption during editing |
-
-Strict mode ensures a YAML typo never accidentally makes a restricted page public. This is a deliberate safety design.
+A malformed `.docplatform/publish.yaml` overlay never knocks pages offline — DocPlatform logs the problem and falls back to each page's frontmatter `publish:` flag.
 
 ## Disk space
 
-### "Low disk space" warning from doctor
-
-**Cause:** DocPlatform warns when free disk space drops below 1 GB.
+### Running low on disk space
 
 **Impact:** SQLite requires free disk space for WAL (write-ahead log) operations. If the disk fills completely, writes fail and data may be corrupted.
 
@@ -319,7 +288,7 @@ If memory usage exceeds 200 MB:
 
 1. Check the number of active WebSocket connections
 2. Check workspace count and total page count
-3. Large git repositories (>5,000 files) use more memory — the hybrid engine auto-switches to native git CLI when go-git exceeds 512 MB RSS
+3. Large git repositories use more memory — the hybrid engine auto-switches to the native git CLI past file-count and memory thresholds
 
 ### Slow page renders
 
@@ -337,6 +306,6 @@ If you can't resolve an issue:
 
 1. Run `docplatform doctor --bundle` to generate a diagnostic bundle
 2. Check the server logs for error messages
-3. Open an issue on GitHub with the diagnostic bundle and relevant log entries
+3. Open an issue on the [Valoryx community tracker](https://github.com/Valoryx-org/community/issues) with the diagnostic bundle and relevant log entries
 
 The diagnostic bundle **does not** contain your content, passwords, or API tokens — only structural metadata and configuration (with secrets redacted).

--- a/reference/zz-changelog.md
+++ b/reference/zz-changelog.md
@@ -10,6 +10,114 @@ All notable changes to DocPlatform are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] — 2026-06-10
+
+### Security
+- **Sudo required on plan-override writes** — admin plan-override endpoints now demand a fresh WebAuthn step-up (#510), with hardened sudo/modal handling in the admin SPA (#509).
+- **Admin logs scrubbed of PII** — the admin binary's root logger is wrapped in a redaction handler (#507); observability mailers redact recipient PII and the metrics listener fails loud on bind errors (#495).
+- **Impersonation minting fenced out of the cloud binary** — regression test guarantees the cloud build cannot mint impersonation tokens (#508).
+- **Webhook event validation on update** — outbound-webhook event lists are validated on update as well as create, with a CI grep audit for SSRF regressions (#500).
+
+### Fixed
+- **Org switcher persisted** — `primary_org_id` is now saved when updating users, so the active organization survives re-login (#506).
+- **Cursor pagination corrected** in cross-org list endpoints — resumes after the cursor row with a stable `id` tiebreaker (#499, #502).
+
+### Changed
+- **Published-site themes single-sourced** — the 7-theme list now lives in one place and every consumer (API, MCP, publishing) validates against it (#503).
+
+## [0.11.0] — 2026-06-01
+
+### Security
+- **Outbound-webhook SSRF closed end-to-end** — create-time URL validation routes through the shared IP blocklist (#485) and delivery-time requests pin IPs and reject redirects (#476).
+- **API-key authorization bypass fixed** alongside a handler test-coverage parity sweep (#474).
+- **Account lockout applied to invitation acceptance** — the per-account lockout now also covers the invitation password path (#455).
+- **AI writing-assist actions whitelisted** at the handler boundary (#478).
+
+### Added
+- **Admin UI (early)** — WebAuthn login fixed end-to-end (#489), organizations list/detail (#492), audit-log viewer with CSV export (#493), sudo step-up modal and session-expiry banner (#491). The admin binary is not yet generally available.
+- **Operational metrics** — internal loopback `/metrics` listener (`METRICS_PORT`) with business gauges (#482) and git-sync worker counters/queue-depth gauge (#487).
+- **PII-scrubbing log handler** for cloud logs (#488).
+- **Playwright smoke suite** wired into CI as a runtime gate (#484).
+
+### Fixed
+- **Importer zip-bomb guard** for archive imports (#465).
+- **Reserved slugs rejected** when renaming an organization (#466).
+- **Release signing fails loud** with a cosign verify round-trip (#468).
+
+### Changed
+- **Frontend CSS built at compile time** — Tailwind JIT replaces the runtime engine, cutting 367 KB of eager vendor JS (#479); the admin SPA carries a no-external-CDN/web-font fence (#481).
+
+## [0.10.0] — 2026-05-16
+
+### Security
+- **Login timing oracle closed** — user enumeration via response timing is no longer possible (#442).
+- **Stored XSS fixed in the markdown render path** (#444) plus a defense-in-depth hardening bundle (#443).
+- **Upload-bomb protection** per SPEC-25 (#422).
+
+### Added
+- **Cloud edition shell** — plan chip, usage display, billing banner (#437), plan-limit upgrade modal (#438), `/api/v1/me/context` bootstrap endpoint (#435), and a clean two-SPA community/cloud split enforced by audit (#434).
+- **GDPR self-service** — personal data export (#420), org export foundation (#419), and password-gated account deletion (#421).
+- **MCP `publish_workspace` tool** with REST publish-toggle parity (#424).
+- **Production observability** — Prometheus alert rules and Grafana panels (#446).
+
+### Fixed
+- **Editor-cap errors unified** to `PLAN_LIMIT_REACHED` across all creation paths (#439).
+- **Dunning/billing email routed to the org creator** (#440).
+- **WebSocket hub goroutine leak on shutdown** (#441); **search engine close made idempotent** (#450).
+
+### Changed
+- **CI hardening** — enforced coverage gate, blocking govulncheck and Trivy scans, `-trimpath` builds (#445).
+
+## [0.9.0] — 2026-04-26
+
+### Added
+- **Publishing overlay (`.docplatform/publish.yaml`)** — git-reviewable publish decisions with read-fallback, write-side sync, and frontmatter-wins-on-write semantics (#387, #388, #389); `nav_order` frontmatter support.
+- **Workspace language** — `language` column wired through to the published site's `<html lang>` (#385).
+- **Reserved-handle validation** for workspace and org slugs (#386).
+- **Pre-deploy smoke test** (`make smoke`) wired into CI (#369, #390).
+- **Admin recovery foundations** — passkey re-enrollment tokens, recovery owner notification, and a 2-of-3 cosign recovery flow (#392–#394); Diceware recovery codes (#383). (Admin binary — not yet generally available.)
+
+### Fixed
+- **Billing webhook idempotency race closed** — atomic gate removes a time-of-check/time-of-use window (#382).
+- **Custom-domain TLS fails loud** when `CADDY_ASK_SECRET` is missing on cloud builds (#399).
+- **"Powered by Valoryx" badge truly hidden on paid plans** — the old relabel branch was removed; free-tier badge links to a plan-aware upgrade nudge (#400).
+
+## [0.8.0] — 2026-04-12
+
+### Added
+- **Workspace rename** from the settings UI (#291).
+- **Clearer member roles** — consistent role labels and an Owner badge (#258); invitation emails state the offered role (#259).
+
+### Fixed
+- **Billing plan validation** — `plan_id` checked against the database and unknown billing intervals rejected (#294).
+- **Git provider handler rejects empty provider names** (#293).
+
+## [0.7.1] — 2026-04-12
+
+### Security
+- **Git credentials encrypted at rest** — workspace `git_remote` credentials are now AES-256-GCM encrypted (#290).
+
+### Fixed
+- **API key creation includes `workspace_id`** (#289).
+
+## [0.7.0] — 2026-04-12
+
+### Added
+- **Drag-and-drop page moves** in the workspace tree (#271).
+- **Editable Welcome page and embedded Help tutorial** (#275).
+- **Published-page indicator** in the workspace tree (#256).
+- **Empty-remote bootstrap** — connecting an empty git repository initializes and pushes automatically, with an `ls-remote` preflight (#253).
+- **Pending invitations list** in workspace settings (#277).
+
+### Fixed
+- **Published sidebar rebuilt on every publish** so new pages appear immediately (#265).
+- **API key scope payload validation** with backfill of legacy rows (#272).
+- **Cookie-consent banner buttons** wired correctly; consent decisions logged (#252).
+- **Upstream tracking set after init-and-push** so subsequent pulls work (#255).
+
+### Changed
+- **Share Links panel removed from the UI** — page access is controlled by site visibility plus invitations (#273).
+
 ## [0.6.4] — 2026-04-08
 
 ### Security
@@ -45,9 +153,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **GoReleaser** — removed `-s -w` strip ldflags that caused SEGV on some platforms.
 - **valoryx.org** — "Join Waitlist" → "Get in Touch" (6 languages), pricing cards show "Best for" personas.
 
-## [1.0.0] — 2026-03-04 (Phase 1)
+## Phase 1 milestone — 2026-03-04
 
-Full commercial release with billing, MCP, custom domains, and admin panel.
+> Historical note: this entry was originally mislabeled "1.0.0". DocPlatform has not shipped a 1.0 release; this milestone landed between 0.5.1 and 0.6.x.
+
+Commercial feature milestone with billing, MCP, custom domains, and the workspace admin panel.
 
 ### Security
 - RS256 JWT (auto-generated RSA key pair, access + refresh tokens, JWKS-ready)

--- a/reference/zz-changelog.md
+++ b/reference/zz-changelog.md
@@ -10,7 +10,7 @@ All notable changes to DocPlatform are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.1] — 2026-06-10
+## [0.11.1] — 2026-06-06
 
 ### Security
 - **Sudo required on plan-override writes** — admin plan-override endpoints now demand a fresh WebAuthn step-up (#510), with hardened sudo/modal handling in the admin SPA (#509).


### PR DESCRIPTION
## Why

Full documentation accuracy pass requested in `.workspace/PROMPT-DOCS-UPDATE.md` (post-v0.11.1 deploy, 2026-06-10). The docs lagged code by ~6 releases — the changelog stopped at 0.6.4, multiple pages documented features that do not exist in code (config.yaml workspace files, JWT TTL env vars, frontmatter access enforcement, slash commands, published-site search, per-plan HTTP rate limits, RFC 7807 errors), and several shipped features were undocumented (publish overlay, nav.yaml, share links, sync-conflict API, llms.txt endpoints, reset-password CLI, MCP publish/resolve tools). Every changed claim below is verified against `Valoryx-org/docplatform` at **origin/main `64c2e84`** — code is the only source of truth.

## Approach

One pass over all 27 markdown pages. Per page: enumerate falsifiable claims, verify each against code (file:line in the Verification Log), fix stale claims, add undocumented features, mark cloud-only features as cloud-edition, and never document broken behavior as working. Voice/structure of each page preserved; `configuration/workspace-config.md` rewritten wholesale (it documented a fictional config file). Changelog gains entries v0.7.0→v0.11.1 and an honesty note on the mislabeled "1.0.0" section. Files changed = all 26 content pages + changelog (see `git diff --name-only origin/main...HEAD`).

## Alternatives Considered

- *Per-section PRs* (getting-started / guides / reference): rejected — cross-page consistency (pricing, role model, registration semantics, MCP count) is the core value of this pass; splitting risks re-introducing drift between pages.
- *Trusting openapi.yaml / PRODUCT-MEMORY for verification*: rejected per prompt — openapi.yaml is stale (v0.5.0, 5-theme enum at `openapi.yaml:999`), and this pass found two PRODUCT-MEMORY drifts (seat counting, git engine — see issues).

## Self-Identified Risks

- **Docs-only PR — no product code changed.** Behavioral risk is limited to readers acting on new instructions.
- The quickstart no longer routes users through `docplatform init`, because CLI-created workspaces land in a server-level default org invisible to web accounts (verified `cmd/server/main.go:602-616`, `internal/auth/service.go:249-334`). If the product later attaches init-workspaces to the first registered user, the quickstart should be revisited (issue filed).
- Changelog entries for v0.7.0–v0.11.1 are distilled from merged-PR titles; granularity choices (what's user-visible) are editorial judgment.
- MCP tool count documented as 26 (25 unconditional + `resolve_sync_conflict` conditional on server-URL config, `internal/mcp/tools.go:69-71`). The integration test asserts 25 with the conditional tool disabled — counting convention could be debated.

## Verification Log

- Compile: not applicable (markdown only). Markdown link targets cross-checked against the repo tree.
- Tests: not applicable (docs repo has no test suite).
- Lint/vet: `git diff --check` clean; no BOM/CRLF artifacts (one PowerShell-introduced BOM caught and reverted during the session).
- Callers traced: not applicable (no code symbols changed).
- API-UI consistency: not applicable.
- Coverage: not applicable.
- Unverified risks: published-page perf numbers in `index.md` (latency/memory table) retained as historical benchmarks — not re-measured; ghcr.io image *publication* verified via `release.yml:115-137` but the package's public visibility not independently confirmed.

**Claim → evidence map (docplatform @ 64c2e84):**

| Changed claim | Evidence |
|---|---|
| Plans/pricing: Free=1ws/3ed/50pg, Team=3/15/150 $29, Business=10/50/∞ $79, Community unlimited | `internal/db/migrations/001_initial.sql:682-699`, `003_plan_pages.sql:5-8`, `008_fix_plan_limits.sql:5-6` |
| Seat = workspace members with `editor`/`workspace_admin` role; viewers/commenters free | `internal/db/workspace_repo.go:320-332`; gate only for editor+ roles `internal/api/handlers/invitation.go:97-110` |
| Limit enforcement points + restricted/paused semantics, 7-day grace | `internal/billing/license.go:81-224`, `internal/billing/service.go:541,553` |
| Custom-domain attach NOT plan-gated (doc claim of paid-only gating removed) | `internal/api/handlers/custom_domain.go:40-103` (no feature check) |
| Badge policy (community/free forced; team/business hidden-by-default, opt-in) | `internal/api/handlers/published.go:475-494,535-552` |
| Analytics gated by plan feature (Community HAS analytics; Cloud Free doesn't); collection consent-based; `days` param; salted-IP consent records | `001_initial.sql:683-698` (features JSON), `internal/api/handlers/analytics.go:45-93,158-203` |
| Themes = 7, single-sourced; invalid → default | `internal/domain/theme.go:21-91` |
| Publish = 3-source decision, overlay wins; unpublished → 404 for everyone; malformed overlay falls back | `internal/publish/service.go:100-145` |
| Site visibility default `authenticated`; `public` opt-in; `PUBLISH_REQUIRE_AUTH` override | `internal/api/handlers/published.go:49-87`, `internal/config/config.go:193` |
| `/p/:slug` single-segment limitation caveat | `internal/api/handlers/published.go:104-105`, `internal/api/router.go:314` |
| 6 discovery endpoints incl. llms.txt/llms-full.txt (200-page cap)/manifest.json | `internal/api/router.go:300-314`, `internal/api/handlers/published.go:288-439` |
| Caching headers Cache-Control 300s + ETag=content hash | `internal/api/handlers/published.go:144-145` |
| CADDY_ASK_SECRET fail-closed | `internal/api/handlers/custom_domain.go:183-211` |
| Components = 15 directives incl. badge/toc/embed; mermaid/katex are `:::` directives (client-rendered); no `$..$`/fenced-mermaid | `internal/publish/components.go:9-29`, `internal/api/handlers/published.go:1018-1031,1199-1227` |
| Renderer goldmark+GFM+auto-heading-IDs+Chroma; **no footnotes**; copy button yes, no line numbers/lang label | `internal/publish/renderer.go:28-55`, `internal/api/handlers/published.go:858-863` |
| Frontmatter fields: `publish` (not `published`), tags FlexTags, status enum, nav_order, seo; `access` parsed NOT enforced | `internal/ledger/frontmatter.go:14-25`, `internal/domain/types.go:62-64` |
| Wikilinks = path-target with `\|alias` + `#heading`; no title/ID resolution | `internal/ledger/wikilink.go:15-23` |
| Registration: every signup creates own org + starter workspace; no first-user-admin | `internal/auth/service.go:249-334` |
| CLI `init` attaches to default org | `cmd/server/main.go:549-616` (`ensureDefaultOrg`) |
| Workspace settings live in DB; `.docplatform/workspace.yaml` = name/desc/theme/css/editor_defaults | `internal/syncyaml/workspace.go:13-26` |
| nav.yaml node types; publish.yaml schema | `internal/syncyaml/nav.go:14-41`, `internal/syncyaml/publish.go:27-50` |
| Auto-merge = 3 manifests only, under `.docplatform/`; nav.yaml + markdown → human | `internal/sync/conflict.go:379-393` |
| Auto-commit message `Update {path} via web editor`, author = acting user; merge commits `sync@valoryx.dev` | `internal/content/service.go:138,212,311,339,395-415`, `internal/sync/conflict.go:28-30` |
| Per-workspace webhook secret (32-byte hex) + GitHub/GitLab/Bitbucket signature headers + branch filter; no GIT_WEBHOOK_SECRET env | `internal/api/handlers/workspace.go:17-18`, `internal/api/handlers/sync.go:32-75,173-183` |
| Git providers: GitHub PAT functional; GitLab/Bitbucket display-only | `internal/gitprovider/github.go:25-46`, `internal/gitprovider/registry.go:56-61` |
| Token encryption AES-256-GCM/Argon2id via GIT_ENCRYPTION_KEY | `internal/gitprovider/cipher.go:15-38`, `internal/config/config.go:225` |
| Hybrid git engine (go-git ↔ native CLI by thresholds) | `internal/git/engine.go:10`, `internal/git/hybrid.go:25-150` |
| Sync interval default 300s min 10s | `internal/git/sync.go:452-455`, `internal/config/config.go:229-233` |
| Search: one shared index, workspace TermQuery scope, en analyzer, scorch+bbolt, fuzzy+highlight, field boosts 3.0/1.5/2.0/1.0; no phrase/prefix/tag syntax; **no published-site search** | `internal/search/bleve.go:19,28-156`, `internal/api/router.go:694-697` |
| JWT 15min/7d fixed (no env); RS256 2048-bit auto-gen; refresh rotation + replay revocation; lockout 5/15min; password 8–1024 | `cmd/server/main.go:212,1427-1451`, `internal/auth/service.go:32-42,374-414,506-547` |
| API keys: `dp_live_`, HMAC-SHA256+pepper, scopes read/write/delete/admin/admin:read, default `[read,write,delete]`, rotate endpoint | `internal/auth/apikey.go:21-87`, `internal/domain/apikey_scope.go:15-62`, `internal/api/handlers/apikeys.go:44-188` |
| OIDC Google/GitHub login real; GitHub email via user:email scope | `internal/auth/oidc.go:30-55,222-346` |
| ws-token cookie 1h SameSite=Strict (not 30s single-use) | `internal/api/handlers/auth.go:233-239` |
| Roles 4 workspace + 2 org levels; action min-levels; editor flags `editor_can_create_pages`(default true)/`delete_pages` | `internal/domain/types.go:29-44,194-201`, `internal/permissions/service.go:15-97` |
| Invitations workspace-scoped (admin+); org member assignment super-admin (`{workspace_id, role}` body); no `/org/invitations` or `POST /workspaces/:id/members` | `internal/api/router.go:467,575-588`, `internal/api/handlers/org.go` (AssignWorkspace) |
| Error shape `{error,message,details,request_id}`; codes incl. PLAN_LIMIT_REACHED; no RFC 7807 | `internal/api/router.go:38-44,806-838` |
| Rate limits: fixed categories (300/60/60/20/min, 5/h register, 5/15min reset, 30/min webhook, 600/min published, 1/24h export); MCP per-plan 30/120/300 | `internal/api/middleware/ratelimit_org.go:34-44`, `ratelimit_ip.go:19-24`, `internal/mcp/ratelimit.go:18-21` |
| MCP 26 tools (25 + conditional resolve_sync_conflict); no trigger_sync; stdio + HTTP `/mcp`; two-layer authz | `internal/mcp/tools.go:18-72`, `resolve_tool.go:342-433`, `transport_http.go:77-206`, `authz.go:40-155` |
| AI: actions improve/simplify/expand/summarize/fix_grammar/translate; body `{action,content,language}`; **no editor AI UI**; 503 when unconfigured | `internal/ai/provider.go:76-101`, `internal/api/handlers/ai.go:21-72`; zero AI refs in `internal/frontend/src/core/{app,editor}.js` |
| Outbound webhook delivery NOT active (CRUD works, deliveries never fire) — documented as "not yet active" | `internal/notifications/service.go:304-365` (`ProcessPending` has no callers; `NewService` never constructed in `cmd/server`) |
| Activity actions page_created/… (underscore form) | `internal/domain/types.go:929`, `internal/api/handlers/activity.go:23-38` |
| Doctor = 11 checks (incl. backups; **no search/disk checks**); bundle at `{DATA_DIR}/diagnostics-{ts}.zip` | `internal/doctor/doctor.go:115-430`, `internal/doctor/bundle.go:18-22` |
| CLI: 10 commands; exact flags; no `--data-dir`, no `.env` loading; reset-password added | `cmd/server/main.go:93,545,549-695,815-816,879,997-998,1103-1104,1228-1229,1319-1320,1345,1410-1411`; config env-only `internal/config/config.go:174-289` |
| Security headers: nosniff + per-surface CSP; X-Frame-Options/HSTS left to proxy; no HOST env | `internal/api/middleware/security.go:72-105`; no HOST in `internal/config/config.go` |
| Telemetry weekly SHA-256 install ID, off by default | `internal/telemetry/telemetry.go:37-137`, `internal/config/config.go:198` |
| Docker: alpine:3.20, UID 1000, EXPOSE 3000, healthcheck 30s/5s/10s/3; ghcr tags latest+version only | `Dockerfile:2-51`, `.github/workflows/release.yml:84-137` |
| Release artifacts `docplatform-{os}-{arch}` (+checksums) | `.goreleaser.yml:93-116` |
| Stripe webhook events list; FF_BILLING; trial 14d default | `internal/billing/service.go:338-346`, `internal/config/config.go:209,265-269` |
| GetLimits JSON shape | `internal/billing/plan_limits.go:18-32` |
| Changelog v0.7.0–v0.11.1 | `git log v0.6.4..64c2e84` + merged-PR titles (#246–#510) |
| Build-from-source/admin-panel/“open source”-adjacent content removed — proprietary, binary-only | product identity per PRODUCT-MEMORY §1; private repo |

## Context Snapshot

No `agents/<agent>/sessions/active-context.md` exists — this is a direct owner-invoked session executing `.workspace/PROMPT-DOCS-UPDATE.md` (fresh Claude Code session in `C:\newValoryx`, 2026-06-10, post-v0.11.1 deploy). Session flow: boot reads (STATE.md, PRODUCT-MEMORY.md) → read-only worktree of docplatform at origin/main `64c2e84` (`worktrees/dp-main-docs-audit`) → 7 parallel code-audit subagents + direct greps for every contested claim → page-by-page fix of all 27 docs files → changelog v0.7.0–v0.11.1 → this PR. Product-truth gaps discovered en route (CLI-init org orphaning, PRODUCT-MEMORY seat-count/git-engine drift) filed on Valoryx-org/issues and noted in `.workspace/STATE.md`.

## Linked

- Prompt: `.workspace/PROMPT-DOCS-UPDATE.md` (workspace-config repo)
- Deploy record: Valoryx-org/issues#166 (v0.11.1)
- Product-truth issues filed from this pass: see comments below PR open (Valoryx-org/issues)
