### PR TITLE
docs: fix 8 blockers + 6 minors from post-merge skeptic review of #3

### DIFF
--- a/configuration/authentication.md
+++ b/configuration/authentication.md
@@ -36,12 +36,11 @@ The memory, iterations, and parallelism parameters are configurable via `ARGON2_
 
 When a user requests a password reset:
 
-- **With SMTP configured** — a one-time reset link is emailed to the user
-- **Without SMTP** — the reset token is printed to stdout (server logs)
+- **With email configured (SMTP or Resend)** — a one-time reset link is emailed to the user
+- **Without email** — nothing is sent, and the link is **not** written to the server logs (the server only notes that an email was skipped). An admin generates a reset link on the server instead:
 
 ```bash
-# Check server logs for the reset token
-docplatform serve 2>&1 | grep "password reset"
+docplatform reset-password --email user@example.com
 ```
 
 The token expires after 1 hour and can only be used once.
@@ -243,7 +242,7 @@ Users can view their active sessions from their profile page (`GET /api/auth/ses
 
 ### Revoking sessions
 
-- **Logout** — ends the current session immediately (the session record is deleted, so even unexpired access tokens stop working)
+- **Logout** — revokes **all** of the user's sessions, on every device (the session records are deleted, so even unexpired access tokens stop working)
 - **Password reset** — all of the user's sessions are revoked automatically
 - **Refresh-token replay** — if a rotated refresh token is ever reused, all of that user's sessions are revoked as a defensive measure
 - **Key rotation** — deleting the JWT key invalidates all sessions globally

--- a/configuration/environment.md
+++ b/configuration/environment.md
@@ -70,7 +70,7 @@ Incoming git webhooks are verified with a **per-workspace secret** that DocPlatf
 
 ## Email (optional)
 
-Configure SMTP or Resend for workspace invitations and password reset emails. Without email configured, tokens are printed to stdout (server logs).
+Configure SMTP or Resend for workspace invitations and password reset emails. Without email configured, these emails are simply not sent and tokens are **not** logged — use `docplatform reset-password` to generate reset links on the server.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/configuration/permissions.md
+++ b/configuration/permissions.md
@@ -110,9 +110,14 @@ curl -X POST http://localhost:3000/api/v1/org/members/:uid/workspaces \
 
 Workspace Admins can change the role of existing members of their workspace (**Workspace Settings → Members**, or `PUT /api/v1/workspaces/:id/admin/members/:user_id/role`).
 
-## Page-level access control (not yet enforced)
+## Page-level access control (avoid — inconsistent)
 
-Page frontmatter may contain an `access` block. DocPlatform **parses and preserves** it (it round-trips through git and the editor unchanged), but it is **not enforced** — all access control today is role-based at the workspace level. Do not rely on frontmatter `access` rules to protect content.
+Page frontmatter may contain an `access` block. Its current behavior is **inconsistent, and you should not use it**:
+
+- While a page carries `access` rules (for example, saved through the web editor or API), reading that page through the API **does enforce them** — members who don't match the rules receive `403 FORBIDDEN` ("insufficient page-level permissions").
+- The next git sync or rebuild **silently strips the `access` block from the file** (the server logs `reconciler: stripping unenforced 'access' frontmatter field`). Stripping prevents privilege escalation through git pushes, but it also discards rules added in good faith.
+
+Net effect: `access` rules neither survive git round-trips nor provide dependable protection. Use workspace-level roles for access control.
 
 ### Published docs access
 

--- a/getting-started/first-workspace.md
+++ b/getting-started/first-workspace.md
@@ -12,7 +12,7 @@ A workspace is the top-level container for a documentation project. Each workspa
 | Concept | Description |
 |---|---|
 | **Workspace** | A documentation project containing pages, members, and settings |
-| **Page** | A Markdown file with YAML frontmatter (title, description, tags, access) |
+| **Page** | A Markdown file with YAML frontmatter (title, description, tags) |
 | **Slug** | The URL-safe identifier for your workspace (e.g., `my-docs` → `/p/my-docs/`) |
 | **Member** | A user with a role in the workspace (Viewer through Admin) |
 
@@ -123,7 +123,7 @@ nav_order: 2          # optional ordering hint for sidebar navigation
 ---
 ```
 
-The `title` is required. All other fields are optional. `tags` accepts either a YAML list or a comma-separated string. An `access` block is parsed and preserved if present, but per-page access control is **not enforced** — permissions are role-based at the workspace level.
+The `title` is required. All other fields are optional. `tags` accepts either a YAML list or a comma-separated string. Avoid the `access` block — it is enforced on API reads while present but silently stripped from the file on the next git sync; rely on workspace-level roles instead.
 
 ## Invite your team
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -23,7 +23,7 @@ DocPlatform has no external dependencies. You don't need to install a database, 
 
 - **Git 2.30+** — only required if you want to sync with a remote git repository
 - **SSH key** — only required for private git repos over SSH
-- **Email provider (SMTP or Resend)** — only required for email invitations and password reset (without email configured, reset links are printed to the server log; admins can also generate them with `docplatform reset-password`)
+- **Email provider (SMTP or Resend)** — only required for email invitations and password reset (without email configured, reset emails are simply not sent and links are **not** logged; admins generate them with `docplatform reset-password`)
 
 ## Architecture at a glance
 

--- a/guides/collaboration.md
+++ b/guides/collaboration.md
@@ -71,16 +71,11 @@ The role is chosen by the inviter at invitation time — there is no separate "d
 
 ### Page-level access
 
-Frontmatter `access` rules are parsed and preserved but **not enforced** — access control is role-based at the workspace level. See [Roles & Permissions](../configuration/permissions.md).
+Frontmatter `access` rules are **inconsistent — avoid them**: they are enforced on API reads while present, but the next git sync silently strips them from the file. Use workspace-level roles instead. See [Roles & Permissions](../configuration/permissions.md).
 
 ## Real-time presence
 
-When multiple users are active in the same workspace, the web editor shows who's online:
-
-- **Sidebar indicators** — colored dots next to pages being viewed or edited by other users
-- **Avatar stack** — user avatars in the page header showing who else is viewing the current page
-
-Presence is powered by WebSocket connections and updates in real time.
+The server tracks who is online per workspace over authenticated WebSocket connections and broadcasts presence events in real time. **The current web UI does not yet display presence** — there are no online indicators or avatar stacks in the editor today. The events are available to custom clients built on the WebSocket API.
 
 ### How presence works
 
@@ -172,7 +167,7 @@ export SMTP_USERNAME=docs@yourcompany.com
 export SMTP_PASSWORD=your-app-password
 ```
 
-Without SMTP, invitation links and password reset tokens are printed to stdout (server logs).
+Without email configured, invitation and password-reset emails are simply not sent — links and tokens are **not** written to the server logs. For password resets, an admin can generate a one-time link with [`docplatform reset-password`](../reference/cli.md).
 
 ## Tips for team workflows
 

--- a/guides/editor.md
+++ b/guides/editor.md
@@ -16,8 +16,8 @@ DocPlatform includes a rich text editor built on Tiptap (ProseMirror-based) that
 │  📁 Getting       │  ┌──────────────────────────────────┐   │
 │     Started       │  │ Frontmatter (collapsible)        │   │
 │  📁 Guides        │  │ Title: ___________________       │   │
-│  📁 API           │  │ Description: ______________      │   │
-│    > auth.md      │  │ Tags: [api] [auth]               │   │
+│  📁 API           │  │ Tags: [api] [auth]               │   │
+│    > auth.md      │  │ Publish: [x]                     │   │
 │    > endpoints    │  └──────────────────────────────────┘   │
 │  📄 changelog     │                                         │
 │                   │  Start writing here...                  │
@@ -41,7 +41,6 @@ The collapsible frontmatter section at the top of the editor provides form field
 | Field | Description | Required |
 |---|---|---|
 | **Title** | Page heading and navigation label | Yes |
-| **Description** | Summary shown in search results and SEO meta tags | No |
 | **Tags** | Categorization labels for filtering and discovery | No |
 | **Publish** | Toggle to include/exclude from the public site | No |
 

--- a/guides/git-integration.md
+++ b/guides/git-integration.md
@@ -110,7 +110,7 @@ curl -X PATCH http://localhost:3000/api/v1/workspaces/{id} \
 
 No restart is required — changes take effect on the next sync cycle.
 
-> **Provider support:** the guided web-UI connection flow supports **GitHub personal access tokens**. GitLab and Bitbucket appear in the provider list but their connection flows are not yet implemented — for those, configure a raw `git_remote` URL (SSH or HTTPS with token) instead.
+> **Provider support:** the guided web-UI connection flow supports **GitHub personal access tokens** — GitHub is the only provider registered today. For GitLab, Bitbucket, or any other git host, configure a raw `git_remote` URL (SSH or HTTPS with token) instead.
 
 ### Authentication
 

--- a/guides/markdown.md
+++ b/guides/markdown.md
@@ -149,7 +149,7 @@ nav_order: 2
 | `status` | string | No | `draft` | Page lifecycle: `draft`, `published`, `archived` |
 | `nav_order` | int | No | — | Ordering hint for sidebar navigation |
 | `seo` | map | No | — | Per-page SEO overrides |
-| `access` | object | No | — | Parsed and preserved, but **not enforced** — see [Permissions](../configuration/permissions.md) |
+| `access` | object | No | — | **Avoid** — enforced on API reads while present, but stripped from the file on git sync; see [Permissions](../configuration/permissions.md) |
 
 ## Custom components
 

--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -190,9 +190,9 @@ Requires an AI provider configured on the server (Anthropic or OpenAI).
 
 | Tool | Description | Key parameters |
 |---|---|---|
-| `docplatform_resolve_sync_conflict` | Resolve a pending git-sync conflict — keep the local version, the remote version, or supply explicit content per path; commits and pushes with your identity | `conflict_id`, `resolution` (`kept_local`, `kept_remote`, `custom`) |
+| `docplatform_resolve_sync_conflict` | Resolve a pending git-sync conflict — keep the local version, the remote version, or supply explicit content per path; commits and pushes with your identity | `conflict_id`, `mode` (`kept_local`, `kept_remote`, `custom`) |
 
-This tool is only registered when the MCP server is started with a configured server URL (`DOCPLATFORM_SERVER_URL`) — it proxies to the REST conflict-resolution endpoint and requires the Editor role. Triggering a sync itself is REST-only (`POST /api/v1/workspaces/:id/sync`); there is no `trigger_sync` MCP tool.
+This tool proxies to the REST conflict-resolution endpoint and requires the Editor role. It is registered by default — the server URL falls back to `http://localhost:3000` when `DOCPLATFORM_SERVER_URL` is unset; set that variable when the API is reachable at a different address. Triggering a sync itself is REST-only (`POST /api/v1/workspaces/:id/sync`); there is no `trigger_sync` MCP tool.
 
 ---
 

--- a/guides/publishing.md
+++ b/guides/publishing.md
@@ -343,9 +343,11 @@ docplatform export --workspace {workspace-id} --output ./my-docs-export.zip
 ### Via API
 
 ```
-POST /api/v1/workspaces/{id}/export   # start the export
-GET  /api/v1/workspaces/{id}/export   # check status / download
+GET  /api/v1/workspaces/{id}/export   # build and download the ZIP (synchronous)
+POST /api/v1/workspaces/{id}/export   # same behavior (compatibility alias)
 ```
+
+The export is synchronous — the ZIP is rendered and streamed in the same request; there is no job to poll.
 
 The export contains:
 

--- a/index.md
+++ b/index.md
@@ -73,14 +73,11 @@ Get DocPlatform running in under 5 minutes:
 # Download the binary (recommended — auto-detects platform)
 curl -fsSL https://valoryx.org/install.sh | sh
 
-# Initialize a workspace
-docplatform init --workspace-name "My Docs" --slug my-docs
-
 # Start the server
 docplatform serve
 ```
 
-Open [http://localhost:3000](http://localhost:3000) and register your first user — they automatically become the Super Admin.
+Open [http://localhost:3000](http://localhost:3000) and register — your account gets its own organization and a starter workspace, and you administer the workspaces you create. (Skip `docplatform init` here: workspaces created from the CLI land in a server-level default organization that web accounts don't see.)
 
 For the complete walkthrough, see the [Getting Started](getting-started/index.md) guide.
 

--- a/reference/api.md
+++ b/reference/api.md
@@ -121,7 +121,7 @@ Create a new user account. Registration creates the user's own organization (the
 }
 ```
 
-**Response:** `201 Created` with the user object; sign in via `/api/auth/login` to obtain tokens.
+**Response:** `201 Created` with `{ "user": ..., "access_token": ..., "expires_at": ... }` plus the refresh-token cookie — registration signs the user in immediately. (If the automatic sign-in step fails, the response contains only the user object; sign in via `/api/auth/login`.)
 
 ### Login
 
@@ -372,7 +372,7 @@ Include the new path in the request body:
 
 ```json
 {
-  "move_to": "new/path/for/page"
+  "new_path": "new/path/for/page"
 }
 ```
 
@@ -665,11 +665,11 @@ Scan a workspace for documentation quality issues. Returns readability scores, d
 ## Static export
 
 ```
-POST /api/v1/workspaces/:id/export   — Start the export
-GET  /api/v1/workspaces/:id/export   — Check status / download
+GET  /api/v1/workspaces/:id/export   — Build and download the ZIP (synchronous)
+POST /api/v1/workspaces/:id/export   — Same behavior (compatibility alias)
 ```
 
-Export all published pages as a static HTML ZIP file.
+Export all published pages as a static HTML ZIP file. The export is **synchronous** — the ZIP is rendered and streamed in the same request; there is no job or status to poll.
 
 ---
 
@@ -695,10 +695,10 @@ GET    /api/v1/workspaces/:id/webhooks/:wid/deliveries — Delivery log (admin)
 ```
 GET    /api/v1/workspaces/:id/comments?page={path}  — List comments (filter by page)
 POST   /api/v1/workspaces/:id/comments              — Create a comment (commenter+)
-PUT    /api/comments/:id                            — Edit a comment
-DELETE /api/comments/:id                            — Delete a comment
-POST   /api/comments/:id/resolve                    — Resolve a thread
-POST   /api/comments/:id/unresolve                  — Reopen a thread
+PUT    /api/v1/comments/:id                         — Edit a comment
+DELETE /api/v1/comments/:id                         — Delete a comment
+POST   /api/v1/comments/:id/resolve                 — Resolve a thread
+POST   /api/v1/comments/:id/unresolve               — Reopen a thread
 ```
 
 ---
@@ -820,7 +820,7 @@ GET /api/health    → 200 OK { "status": "ok", "version": "v0.10.0" }
 GET /api/ready     → 200 OK { "status": "ready", "checks": { ... } }
 ```
 
-The `/api/ready` endpoint reports readiness of the database, git engine, and job outbox.
+The `/api/ready` endpoint reports readiness of the database, the availability of the `git` binary, and the email outbox backlog.
 
 ---
 
@@ -940,7 +940,7 @@ POST /api/auth/ws-token
 
 WebSocket connections use an HttpOnly cookie mechanism to avoid exposing tokens in URLs.
 
-**Response:** `200 OK`
+**Response:** `204 No Content`
 
 Sets a `dp_ws_token` HttpOnly, SameSite=Strict cookie (valid for 1 hour).
 


### PR DESCRIPTION
## Why

Post-merge skeptic verification of the #3 accuracy pass (fresh adversarial session, ~85 claims re-checked against docplatform `origin/main` @ `76222ac`) found 8 claims contradicted by code — two of them security-adjacent in the dangerous direction — plus 6 minor inaccuracies. PR #3 was merged while the skeptic was still running, so these land as a fix-forward.

## What changed (each verified at file:line before fixing)

**Blockers**

1. **`access` frontmatter — wrong on both halves** (permissions.md, collaboration.md, markdown.md, first-workspace.md). Docs said "parsed and preserved… not enforced". Code: API reads DO enforce it while present (403 via `EvaluatePageAccess`, `internal/api/handlers/content.go:81-86`) and the reconciler **strips it from the file on git sync** (`internal/ledger/reconciler.go:175-186`). Rewritten as "inconsistent — avoid": enforced on reads, silently stripped on sync, use workspace roles.
2. **Reset links are never logged** (authentication.md, environment.md, getting-started/index.md, collaboration.md). Docs claimed tokens print to server logs; the sender logs only `email not sent (not configured)` with to+subject (`internal/email/sender.go:536-563`). Replaced the phantom recovery path with `docplatform reset-password`.
3. **Presence has no UI** (collaboration.md). Removed "sidebar indicators"/"avatar stack" claims — zero presence consumers in `internal/frontend/src`. Backend events/heartbeats kept, documented as WebSocket-API-only.
4. Move body is `new_path`, not `move_to` (api.md; `internal/content/service.go:319`).
5. Export is synchronous on both verbs — no job/status to poll (api.md, publishing.md; `internal/api/handlers/export.go:37`).
6. Registration auto-logs-in: 201 with `{user, access_token, expires_at}` + refresh cookie (api.md; `internal/api/handlers/auth.go:68-86`).
7. Comment moderation routes live under `/api/v1/comments/...` (api.md; `internal/api/router.go:438,665-668`).
8. `resolve_sync_conflict` is registered by default (`DOCPLATFORM_SERVER_URL` falls back to `http://localhost:3000`, `internal/mcp/resolve_tool.go:38-39`) and its parameter is `mode` (mcp.md).

**Minors:** root index.md quickstart no longer routes through `docplatform init` (default-org orphaning, ops#242) and drops the false "first user becomes Super Admin"; GitHub is the only registered git provider (git-integration.md; `cmd/server/main.go:429`); ws-token returns 204 (api.md); logout revokes ALL sessions (authentication.md; `LogoutAll`); editor frontmatter form has no Description field (editor.md; `editor.js:403-422`); `/api/ready` checks db + git binary + email outbox (api.md; `internal/api/handlers/health.go:80-109`).

**Not addressed here:** the changelog's v0.11.0 no-tag note (release-engineering gap; the v0.11.3 release pipeline regenerates `reference/zz-changelog.md` from docplatform's backfilled CHANGELOG — docplatform PR #517).

## Verification

- Every fix's contradicting code evidence re-read directly in the docplatform worktree before editing (not taken from the skeptic's report on trust): reconciler strip block, ReadPage enforcement, email sender, resolve_tool default + `mode`, WebAuthn presence in end-user auth (landing-page claim verified TRUE — left unchanged).
- `git diff --check` clean; 13 files, +40/−43, docs-only.

## Linked

- Fix-forward for: #3 (merged)
- Related: ops#242 (CLI-init orphaning), Valoryx-org/docplatform#517 (CHANGELOG backfill)
