### PR TITLE
billing/permissions: Business page cap 500/workspace (owner-ratified, matches docplatform#523)

### DIFF
--- a/configuration/permissions.md
+++ b/configuration/permissions.md
@@ -198,7 +198,7 @@ Community Edition is free and self-hosted with no license key required:
 | **Workspaces** | 1 | 3 | 10 |
 | **Seats** (Super Admin + Admin + Editor) | 3 | 15 | 50 |
 | **Viewers & Commenters** | Unlimited | Unlimited | Unlimited |
-| **Pages** | 50 | 150 | Unlimited |
+| **Pages** | 50 | 150 | 500 |
 
 > Need more? [Contact sales](https://valoryx.org/contact) for Enterprise plans with custom limits, SSO, and SLA.
 

--- a/guides/billing.md
+++ b/guides/billing.md
@@ -16,7 +16,7 @@ DocPlatform Cloud uses Stripe for subscription billing across three cloud tiers:
 | **Editor seats** (Editor + Admin roles) | Unlimited | 3 | 15 | 50 |
 | **Workspaces** | Unlimited | 1 | 3 | 10 |
 | **Viewers / Commenters** | Unlimited | Unlimited | Unlimited | Unlimited |
-| **Pages per workspace** | Unlimited | 50 | 150 | Unlimited |
+| **Pages per workspace** | Unlimited | 50 | 150 | 500 |
 | **Published docs** | Unlimited | Unlimited | Unlimited | Unlimited |
 | **Analytics** | Included | — | Included | Included |
 | **Custom domains** | Included | — | Included | Included |


### PR DESCRIPTION
Owner-ratified 2026-06-11: Business = 500 pages per workspace (cloud-only; Community stays unlimited). Companion to Valoryx-org/docplatform#523 (migration 034) and the valoryx.org PR. Two plan-table cells; merging triggers the docs-to-site mirror for the en site docs.