### PR TITLE
docs(mcp): clarify MCP is self-hosted-only; managed cloud has no MCP endpoint

### DIFF
--- a/guides/mcp.md
+++ b/guides/mcp.md
@@ -7,6 +7,8 @@ description: Connect AI tools like Claude Code, Claude Desktop, Cursor, and VS C
 
 DocPlatform includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets AI assistants read, write, search, and manage your documentation directly. Instead of copy-pasting content into chat windows, your AI tools work with your docs natively.
 
+> **MCP runs against a DocPlatform instance you operate yourself.** The MCP server is built into the DocPlatform binary and reads that instance's local data directory directly — it is not a network client that logs in to a remote server. So MCP works with the self-hosted **Community Edition** (and any cloud-edition binary you run yourself). The managed **DocPlatform Cloud** at [app.valoryx.dev](https://app.valoryx.dev) does **not** currently expose an MCP endpoint, so AI tools cannot yet connect to a managed-cloud workspace over MCP. This guide assumes you are running your own instance.
+
 ## Prerequisites
 
 - DocPlatform running (binary, Docker, or Fly.io)
@@ -25,7 +27,7 @@ DocPlatform offers two MCP transports:
 | Transport | Command | Use case |
 |---|---|---|
 | **stdio** | `docplatform mcp` | Local AI tools (Claude Desktop, Claude Code, Cursor) |
-| **Streamable HTTP** | `docplatform mcp-server` | Remote/cloud access, multi-workspace |
+| **Streamable HTTP** | `docplatform mcp-server` | Remote access to a self-hosted instance, multi-workspace |
 
 ### 3. Configure your AI tool
 
@@ -80,9 +82,9 @@ Add to `.vscode/mcp.json`:
 }
 ```
 
-#### Remote HTTP transport
+#### Remote HTTP transport (self-hosted)
 
-For cloud-hosted DocPlatform or multi-workspace access, start the HTTP server:
+To reach an instance you run yourself over the network — for remote or multi-workspace access — start the HTTP server on that instance:
 
 ```bash
 docplatform mcp-server --addr :8081


### PR DESCRIPTION
## Why

Stream **D-docs** of the launch push (coordination on `Valoryx-org/issues#306`): bring the official docs in line with shipped reality for v0.11.6. The `guides/mcp.md` guide misleads readers into thinking the built-in MCP server connects AI tools to the **managed** DocPlatform Cloud (`app.valoryx.dev`):
- transports table: "**Remote/cloud access**, multi-workspace"
- HTTP section: "**For cloud-hosted DocPlatform** or multi-workspace access, start the HTTP server" → `http://your-server:8081/mcp`

Code says otherwise. Both transports open a **local** store and read the local data dir — neither is a network client for a remote managed server, and the managed cloud exposes **no MCP endpoint of any kind** today:
- `product/docplatform/cmd/server/main.go:970` (`mcpCmd`, stdio) → `db.NewSQLiteStorage(cfg.DatabasePath())` + `cfg.DataDir`.
- `product/docplatform/cmd/server/main.go:1079` (`mcpServerCmd`, HTTP) → same local `db.NewSQLiteStorage(cfg.DatabasePath())` + `cfg.DataDir`; `DOCPLATFORM_SERVER_URL` only feeds the single `resolve_sync_conflict` proxy tool, not the data path.
- Managed cloud has no MCP route: `/mcp` is not routed (ops#306 lists `B-mcp #33` as **unbuilt**; the deploy runbook runs `./cmd/server` as the web binary, not `mcp-server`). Tracked by **ops#248** (deploy mcp-server + route, or keep the honesty callout). No internal issue number is printed in the public doc (matches the existing webhook-honesty convention in `reference/api.md`).

This is broader than the originating prompt's "HTTP-only" framing: the prompt assumed only the HTTP transport needed the caveat, but stdio is equally local, so the callout covers both.

## Approach

Docs-only edit to a single file, `guides/mcp.md` (`git diff --name-only origin/main...HEAD` = `guides/mcp.md` only):
1. **New top-of-guide callout** after the intro: MCP runs against an instance you operate yourself (Community Edition or a self-hosted cloud-edition binary); the managed cloud at app.valoryx.dev does not currently expose an MCP endpoint, so AI tools cannot yet connect to a managed-cloud workspace over MCP.
2. **Transports table**: "Remote/cloud access, multi-workspace" → "Remote access to a self-hosted instance, multi-workspace".
3. **HTTP-transport section**: heading "Remote HTTP transport" → "Remote HTTP transport (self-hosted)"; intro "For cloud-hosted DocPlatform or multi-workspace access" → "To reach an instance you run yourself over the network — for remote or multi-workspace access". The command + connect example are unchanged (they are correct for self-hosting).

## Alternatives Considered

- **Scope the callout to only the HTTP section (as the prompt outlined).** Rejected — stdio is equally local per code; limiting the caveat to HTTP would leave the stdio "Quick start" examples implying a managed-cloud customer can connect, which is false.
- **Cite ops#248 inline in the doc.** Rejected — docplatform-docs is public; internal tracker numbers don't belong in published docs. The existing webhook-honesty note in `reference/api.md` sets the precedent (no issue ref). ops#248 is cited here and on the gate handoff instead.
- **Also update index.md Business page cap.** Rejected as unnecessary — re-verification showed it is already correct (see Verification Log); the "Unlimited" rows in index.md are the Community self-hosted table.

## Self-Identified Risks

- **None behavioral — pure docs.** No code, no frontmatter, no links removed. The only residual concern is forward-accuracy: if ops#248 is later resolved by deploying a hosted MCP endpoint, this callout must be revised in the same change that ships the endpoint. Flagged on the gate handoff.

## Verification Log

All claims re-verified against `origin/main` at boot (2026-06-14) because the prompt's gap list predated concurrent merges.

- **Compile/Tests/Lint:** N/A — docs-only repo (no Makefile / package.json / linter; `.github/workflows/` holds only `sync-to-website.yml`). Markdown structure checked manually: new blockquote, table row (3 cells intact), and `####` heading are all valid; em-dash style matches the existing file; `[app.valoryx.dev](https://app.valoryx.dev)` link form matches `guides/billing.md`.
- **Gap #1 — MCP tool count (26):** ✅ already correct, no change. `guides/ai-features.md` ("**26 tools**"), `guides/mcp.md` ("## Available tools (26)"), `index.md` ("MCP server (26 tools)") all agree; matches `product/docplatform/internal/mcp/tools.go` + `tools_new.go` (26 distinct tools).
- **Gap #2 — outbound webhook honesty:** ✅ already correct, no change. `reference/api.md` carries "⚠️ **Outbound webhook delivery is not yet active.** … events are **not currently delivered**". Matches PRODUCT-MEMORY §5 (PR #527 wired flag-OFF, `webhook_delivery_enabled` default OFF).
- **Gap #4 — Business page cap 500:** ✅ already on main, no change. `guides/billing.md` table: `| **Pages per workspace** | Unlimited | 50 | 150 | 500 |` (landed via PR #5 `7768b8a`). `index.md` "Unlimited" entries are the **Community self-hosted** capability table (correct — Community is unbound). Matches PRODUCT-MEMORY §1 (Business = 500/workspace, migration 034).
- **Gap #3/#6 — MCP cloud honesty (THIS PR):** 🔴 fixed. Source-of-truth: `product/docplatform/cmd/server/main.go:970` (mcpCmd → local `db.NewSQLiteStorage` + `cfg.DataDir`), `:1079` (mcpServerCmd → local store; `DOCPLATFORM_SERVER_URL` only for the resolve proxy). Managed-cloud has no MCP endpoint: ops#248 OPEN; ops#306 `B-mcp #33` unbuilt.
- **Callers traced:** none — no symbols, no code. API-UI consistency: N/A (no handler).
- **Coverage for changed files:** N/A (docs).
- **Unverified risks:** download-link liveness (index.md / installation.md) and the `valoryx.org/install.sh` link are **out of scope** — owned by C-site (cross-repo), deferred per the stream's collision rule. Non-EN mirror sync (ops#246) is an owner decision (translate vs drop) — documented as pending, not actioned.

## Context Snapshot

```
---
agent: ops-agent
session_started: 2026-06-14
last_updated: 2026-06-14
north_star: "Bring docplatform-docs in line with shipped reality for v0.11.6 (Stream D-docs, ops#306)."
current_task: "MCP cloud-vs-self-hosted honesty callout in guides/mcp.md; verify the other pre-listed gaps already closed on main."
next_action: "PR open + gate handoff filed on ops#306. Stop (teammate; author != merger; no merge, no deploy, no STATE.md edit)."
status: pr-open-awaiting-gate
---

## Decisions & Why
- Re-verified all four pre-listed gaps against origin/main at boot (prompt warned merge state moves under concurrency). Three were already satisfied:
  - #1 MCP 26-tool count: correct (ai-features.md, mcp.md `## Available tools (26)`, index.md).
  - #2 Outbound webhook honesty: reference/api.md already carries "Outbound webhook delivery is not yet active."
  - #4 Business page cap 500: already merged via docplatform-docs PR #5 (7768b8a) - billing.md shows Pages per workspace ... 500. The remaining "Unlimited" in index.md is the Community self-hosted table (correct).
- Only real gap = #3/#6 (MCP cloud honesty) - and it is BROADER than the prompt framed. Code (cmd/server/main.go mcpCmd L970 / mcpServerCmd L1079) shows BOTH stdio and HTTP transports open a local SQLite store and read the local data dir; neither is a remote client. So MCP only works against a self-hosted instance; the managed cloud (app.valoryx.dev) exposes no MCP endpoint of any kind (/mcp not routed, ops#248 OPEN, ops#306 B-mcp #33 unbuilt). The prompt's "HTTP-only" framing would itself be inaccurate.
- No internal issue numbers in the public doc - matched the existing webhook-honesty convention in api.md. ops#248 cited only in PR body / gate handoff.

## Files Touched This Session
- product/docplatform-docs/guides/mcp.md (worktree worktrees/docs-accuracy-0116, branch build/docs-accuracy-v0116): +1 top callout, transports-table wording, HTTP-section heading/sentence.
- agents/ops-agent/sessions/active-context.md (this file).

## Open Artifacts
- PRs opened this session: docplatform-docs build/docs-accuracy-v0116 (docs-only MCP honesty callout).
- Handoffs: claim on ops#306 (D-docs) + ops#246; gate-handoff to be filed on ops#306.
- Branches active: build/docs-accuracy-v0116 (worktree worktrees/docs-accuracy-0116).

## Do-Not-Lose
- Stale fix/business-page-cap-500 worktree (worktrees/docs-biz-cap, d674afa) is superseded by squash-merged PR #5 - cleanup candidate, NOT touched (flagged on the gate handoff).
```

## Linked

- Coordination: `Valoryx-org/issues#306` (Stream D-docs).
- Owner decision (pending, non-blocking): `Valoryx-org/issues#246` (non-EN mirror translate/drop).
- Related (internal, not printed in the doc): `Valoryx-org/issues#248` (no cloud MCP endpoint) · `Valoryx-org/issues#33` (B-mcp `/mcp` routing, unbuilt).
